### PR TITLE
Chavic/enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,7 @@ description = "Dart Frontend for UniFFI"
 [features]
 defaults = []
 binary = []
-build = [
-    "dep:uniffi_build",
-]
+build = ["dep:uniffi_build"]
 bindgen-tests = [
     "dep:uniffi_testing",
     "dep:camino-tempfile",
@@ -33,22 +31,24 @@ required-features = ["binary"]
 anyhow = "1"
 paste = "1"
 heck = "0.4.1"
-uniffi = "0.23.0"
-uniffi_bindgen = "0.23.0"
-camino ="1"
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "8565b7f941e7967778efd39c5ab27551dfa23ec6", features = [
+    "build",
+] }
+uniffi_bindgen = { git = "https://github.com/mozilla/uniffi-rs", rev = "8565b7f941e7967778efd39c5ab27551dfa23ec6" }
+camino = "1"
 serde = "1"
 toml = "0.5"
 genco = "0.17.5"
 proc-macro2 = "1.0.66"
 
 # feature specific stuff
-uniffi_build = { version = "0.23.0", optional = true }
+uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "8565b7f941e7967778efd39c5ab27551dfa23ec6", optional = true }
 
 # optional for testint
-uniffi_testing = { version = "0.23.0", optional = true }
+uniffi_testing = { git = "https://github.com/mozilla/uniffi-rs", rev = "8565b7f941e7967778efd39c5ab27551dfa23ec6", optional = true }
 fs_extra = { version = "1.3.0", optional = true }
 camino-tempfile = { version = "1.0.2", optional = true }
-glob = { version = "0.3.1", optional = true}
+glob = { version = "0.3.1", optional = true }
 
 [workspace]
 

--- a/fixtures/arithmetic/Cargo.toml
+++ b/fixtures/arithmetic/Cargo.toml
@@ -11,11 +11,14 @@ name = "simple_arithmetic"
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-uniffi = "0.23.0"
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "8565b7f941e7967778efd39c5ab27551dfa23ec6" }
 
 [build-dependencies]
-uniffi-dart = { path = "../../",  features = ["build"] }
+uniffi-dart = { path = "../../", features = ["build"] }
 
 [dev-dependencies]
 uniffi-dart = { path = "../../", features = ["bindgen-tests"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "8565b7f941e7967778efd39c5ab27551dfa23ec6", features = [
+  "bindgen-tests",
+] }
 anyhow = "1"

--- a/fixtures/arithmetic/src/lib.rs
+++ b/fixtures/arithmetic/src/lib.rs
@@ -11,8 +11,8 @@ pub fn multiply(left: u32, right: u32) -> u32 {
 }
 
 #[uniffi::export]
-pub fn devide(left: u32, right: u32) -> u32 {
-    left / right
+pub fn devide(left: u32, right: u32) -> Option<u32> {
+   Some(left / right)
 }
 
 #[uniffi::export]

--- a/fixtures/arithmetic/src/lib.rs
+++ b/fixtures/arithmetic/src/lib.rs
@@ -10,10 +10,15 @@ pub fn multiply(left: u32, right: u32) -> u32 {
     left * right
 }
 
-// #[uniffi::export]
-// pub fn devide(left: u32, right: u32) -> Option<u32> {
-//     left.checked_div(right)
-// }
+#[uniffi::export]
+pub fn devide(left: u32, right: u32) -> u32 {
+    left / right
+}
+
+#[uniffi::export]
+pub fn devide_checked(left: u32, right: u32) -> Option<u32> {
+    left.checked_div(right)
+}
 
 #[uniffi::export]
 pub fn add_u8(left: u8, right: u8) -> u8 {

--- a/fixtures/arithmetic/src/lib.rs
+++ b/fixtures/arithmetic/src/lib.rs
@@ -1,13 +1,13 @@
 use uniffi;
 
 #[uniffi::export]
-pub fn add(left: u32, right: u32) -> u32 {
-    left + right
+pub fn add(left: u32, right: u32) -> Option<u32> {
+    Some(left + right)
 }
 
 #[uniffi::export]
-pub fn multiply(left: u32, right: u32) -> u32 {
-    left * right
+pub fn multiply(left: u32, right: u32) -> Option<u32> {
+    Some(left * right)
 }
 
 #[uniffi::export]
@@ -21,38 +21,48 @@ pub fn devide_checked(left: u32, right: u32) -> Option<u32> {
 }
 
 #[uniffi::export]
-pub fn add_u8(left: u8, right: u8) -> u8 {
-    left + right
+pub fn add_u8(left: u8, right: u8) -> Option<u8> {
+    Some(left + right)
 }
 
 #[uniffi::export]
-pub fn add_u16(left: u16, right: u16) -> u16 {
-    left + right
+pub fn add_u16(left: u16, right: u16) -> Option<u16> {
+    Some(left + right)
 }
 
 #[uniffi::export]
-pub fn add_u64(left: u64, right: u64) -> u64 {
-    left + right
+pub fn add_u64(left: u64, right: u64) -> Option<u64> {
+    Some(left + right)
 }
 
 #[uniffi::export]
-pub fn add_i8(left: i8, right: i8) -> i8 {
-    left + right
+pub fn add_i8(left: i8, right: i8) -> Option<i8> {
+    Some(left + right)
 }
 
 #[uniffi::export]
-pub fn add_i16(left: i16, right: i16) -> i16 {
-    left + right
+pub fn add_i16(left: i16, right: i16) -> Option<i16> {
+    Some(left + right)
 }
 
 #[uniffi::export]
-pub fn add_i32(left: i32, right: i32) -> i32 {
-    left + right
+pub fn add_i32(left: i32, right: i32) -> Option<i32> {
+    Some(left + right)
 }
 
 #[uniffi::export]
-pub fn add_i64(left: i64, right: i64) -> i64 {
-    left + right
+pub fn add_i64(left: i64, right: i64) -> Option<i64> {
+   Some( left + right)
+}
+
+#[uniffi::export]
+pub fn add_f32(left: f32, right: f32) -> Option<f32> {
+   Some(left + right)
+}
+
+#[uniffi::export]
+pub fn add_f64(left: f64, right: f64) -> Option<f64> {
+   Some(left + right)
 }
 
 include!(concat!(env!("OUT_DIR"), "/api.uniffi.rs"));

--- a/fixtures/arithmetic/test/simple_arithmetic_test.dart
+++ b/fixtures/arithmetic/test/simple_arithmetic_test.dart
@@ -40,4 +40,10 @@ void main() {
   test('i64', () {
     expect(api.addI64(2, 2), 4);
   });
+  test('f32', () {
+    expect(api.addF32(2.0, 2.0), 4.0);
+  });
+  test('f64', () {
+    expect(api.addF64(2.0, 2.9), 4.9);
+  });
 }

--- a/fixtures/arithmetic/test/simple_arithmetic_test.dart
+++ b/fixtures/arithmetic/test/simple_arithmetic_test.dart
@@ -9,11 +9,14 @@ void main() {
   test('2 * 8 = 16', () {
     expect(api.multiply(2, 8), 16);
   });
-  test('8 * 2 = 4', () {
-    expect(api.devide(8, 2), 4);
+  test('2 / 8 = 0', () {
+    expect(api.devideChecked(2, 8), 0);
   });
-  test('2 / 8 = null', () {
-    expect(api.devideChecked(2, 8), null);
+  test('8 / 0 = null', () {
+    expect(api.devideChecked(8, 0), null);
+  });
+  test('8 / 2 = 4', () {
+    expect(api.devide(8, 2), 4);
   });
   test('u8', () {
     expect(api.addU8(2, 2), 4);

--- a/fixtures/arithmetic/test/simple_arithmetic_test.dart
+++ b/fixtures/arithmetic/test/simple_arithmetic_test.dart
@@ -9,6 +9,12 @@ void main() {
   test('2 * 8 = 16', () {
     expect(api.multiply(2, 8), 16);
   });
+  test('8 * 2 = 4', () {
+    expect(api.devide(8, 2), 4);
+  });
+  test('2 / 8 = null', () {
+    expect(api.devideChecked(2, 8), null);
+  });
   test('u8', () {
     expect(api.addU8(2, 2), 4);
   });

--- a/fixtures/arithmetic/tests/mod.rs
+++ b/fixtures/arithmetic/tests/mod.rs
@@ -2,5 +2,5 @@ use anyhow::Result;
 
 #[test]
 fn simple_arithmetic() -> Result<()> {
-    uniffi_dart::testing::run_test("simple_arithmetic")
+    uniffi_dart::testing::run_test("simple_arithmetic", "src/api.udl", None)
 }

--- a/fixtures/hello_world/Cargo.toml
+++ b/fixtures/hello_world/Cargo.toml
@@ -10,12 +10,18 @@ publish = false
 name = "hello_world"
 crate-type = ["lib", "cdylib"]
 
+
 [dependencies]
-uniffi = "0.23.0"
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "8565b7f941e7967778efd39c5ab27551dfa23ec6", features = [
+  "build",
+] }
 
 [build-dependencies]
-uniffi-dart = { path = "../../",  features = ["build"] }
+uniffi-dart = { path = "../../", features = ["build"] }
 
 [dev-dependencies]
 uniffi-dart = { path = "../../", features = ["bindgen-tests"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "8565b7f941e7967778efd39c5ab27551dfa23ec6", features = [
+  "bindgen-tests",
+] }
 anyhow = "1"

--- a/fixtures/hello_world/tests/mod.rs
+++ b/fixtures/hello_world/tests/mod.rs
@@ -2,5 +2,5 @@ use anyhow::Result;
 
 #[test]
 fn hello_world() -> Result<()> {
-    uniffi_dart::testing::run_test("hello_world")
+    uniffi_dart::testing::run_test("hello_world", "src/api.udl", None)
 }

--- a/fixtures/large_enum/Cargo.toml
+++ b/fixtures/large_enum/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "large_enum"
+version = "0.1.0"
+edition = "2021"
+publish = false
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+
+[lib]
+name = "large_enum"
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "8565b7f941e7967778efd39c5ab27551dfa23ec6", features = [
+  "build",
+] }
+
+[build-dependencies]
+uniffi-dart = { path = "../../", features = ["build"] }
+
+[dev-dependencies]
+uniffi-dart = { path = "../../", features = ["bindgen-tests"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs", rev = "8565b7f941e7967778efd39c5ab27551dfa23ec6", features = [
+  "bindgen-tests",
+] }
+anyhow = "1"

--- a/fixtures/large_enum/build.rs
+++ b/fixtures/large_enum/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi_dart::generate_scaffolding("./src/api.udl".into()).unwrap();
+}

--- a/fixtures/large_enum/src/api.udl
+++ b/fixtures/large_enum/src/api.udl
@@ -1,0 +1,1 @@
+namespace large_enum {};

--- a/fixtures/large_enum/src/lib.rs
+++ b/fixtures/large_enum/src/lib.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum Shape {
+    Circle,
+    Rectangle,
+}
+
+include!(concat!(env!("OUT_DIR"), "/api.uniffi.rs"));

--- a/fixtures/large_enum/src/lib.rs
+++ b/fixtures/large_enum/src/lib.rs
@@ -1,7 +1,188 @@
-#[derive(Debug, Clone, uniffi::Enum)]
-pub enum Shape {
-    Circle,
-    Rectangle,
+use uniffi::{Enum, Record};
+
+#[derive(Clone, Debug, Enum)]
+pub enum Instruction {
+    CallMethod1 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod2 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod3 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod4 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod5 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod6 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod10 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod11 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod12 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod13 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod14 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod15 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod16 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod17 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod18 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod19 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod20 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod21 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod22 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod23 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod24 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod25 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod26 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+    CallMethod27 {
+        object: Value,
+        method_name: Value,
+        args: Value,
+    },
+}
+
+#[derive(Debug, Clone, Enum)]
+pub enum Value {
+    String {
+        value: String,
+    },
+    Bool {
+        value: bool,
+    },
+
+    U8 {
+        value: u8,
+    },
+    U16 {
+        value: u16,
+    },
+    U32 {
+        value: u32,
+    },
+    U64 {
+        value: u64,
+    },
+
+    I8 {
+        value: i8,
+    },
+    I16 {
+        value: i16,
+    },
+    I32 {
+        value: i32,
+    },
+    I64 {
+        value: i64,
+    },
+    Enum {
+        discriminator: u8,
+        fields: Vec<Value>,
+    },
+    NonHomogenousCollection {
+        elements: Vec<Value>,
+    },
+    HomogenousCollection {
+        elements: Vec<Value>,
+    },
+    Map {
+        entries: Vec<MapEntry>,
+    },
+    PublicKey {
+        value: Vec<u8>,
+    },
+    Signature {
+        value: Vec<u8>,
+    },
+}
+
+#[derive(Clone, Debug, Record)]
+pub struct MapEntry {
+    pub key: Value,
+    pub value: Value,
 }
 
 include!(concat!(env!("OUT_DIR"), "/api.uniffi.rs"));

--- a/fixtures/large_enum/test/large_enum_test.dart
+++ b/fixtures/large_enum/test/large_enum_test.dart
@@ -1,0 +1,6 @@
+import 'package:test/test.dart';
+import '../large_enum.dart';
+
+void main() {
+  final api = Api.load();
+}

--- a/fixtures/large_enum/tests/mod.rs
+++ b/fixtures/large_enum/tests/mod.rs
@@ -1,0 +1,6 @@
+use anyhow::Result;
+
+#[test]
+fn large_enum() -> Result<()> {
+    uniffi_dart::testing::run_test("large_enum", "src/api.udl", None)
+}

--- a/src/build.rs
+++ b/src/build.rs
@@ -10,6 +10,7 @@ pub fn generate_scaffolding(udl_file: &Utf8Path) -> Result<()> {
         udl_file,
         None::<&Utf8Path>,
         Some(out_dir),
+        None::<&Utf8Path>,
     )?;
     Ok(())
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -288,11 +288,11 @@ impl BindingsGenerator {
                 return RustBuffer.fromBytes(api, bytes.ref);
             }
 
-            T? liftOptional<T>(Api api, Uint8List buf, T Function(Api, Uint8List) lifter) {
+            T? liftOptional<T>(Api api, Uint8List buf, T? Function(Api, Uint8List) lifter) {
                 if (buf.isEmpty || buf.first == 0){
                     return null;
                 }
-                return lifter(api, buf.sublist(5));
+                return lifter(api, buf);
             }
 
             Uint8List lowerOptional<T>(Api api, T? inp, Uint8List Function(Api, T) lowerer) {

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -1,12 +1,13 @@
+use std::collections::HashMap;
+
 use anyhow::{Context, Result};
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use genco::fmt;
 use genco::prelude::*;
 use serde::{Deserialize, Serialize};
-use toml::Value;
-use uniffi_bindgen::MergeWith;
-use uniffi_bindgen::{BindingGenerator, BindingGeneratorConfig, ComponentInterface};
+// use uniffi_bindgen::MergeWith;
+use uniffi_bindgen::{BindingGenerator, BindingsConfig, ComponentInterface};
 
 mod enums;
 mod functions;
@@ -22,24 +23,24 @@ pub struct Config {
     cdylib_name: Option<String>,
 }
 
-impl MergeWith for Config {
-    fn merge_with(&self, other: &Self) -> Self {
-        let package_name = if other.package_name.is_some() {
-            other.package_name.clone()
-        } else {
-            self.package_name.clone()
-        };
-        let cdylib_name = if other.cdylib_name.is_some() {
-            other.cdylib_name.clone()
-        } else {
-            self.cdylib_name.clone()
-        };
-        Self {
-            package_name,
-            cdylib_name,
-        }
-    }
-}
+// impl MergeWith for Config {
+//     fn merge_with(&self, other: &Self) -> Self {
+//         let package_name = if other.package_name.is_some() {
+//             other.package_name.clone()
+//         } else {
+//             self.package_name.clone()
+//         };
+//         let cdylib_name = if other.cdylib_name.is_some() {
+//             other.cdylib_name.clone()
+//         } else {
+//             self.cdylib_name.clone()
+//         };
+//         Self {
+//             package_name,
+//             cdylib_name,
+//         }
+//     }
+// }
 
 impl From<&ComponentInterface> for Config {
     fn from(ci: &ComponentInterface) -> Self {
@@ -68,28 +69,42 @@ impl Config {
     }
 }
 
-impl BindingGeneratorConfig for Config {
-    fn get_entry_from_bindings_table(_bindings: &Value) -> Option<Value> {
-        if let Some(table) = _bindings.as_table() {
-            table.get("dart").map(|v| v.clone())
-        } else {
-            None
-        }
+impl BindingsConfig for Config {
+    // fn get_entry_from_bindings_table(_bindings: &Value) -> Option<Value> {
+    //     if let Some(table) = _bindings.as_table() {
+    //         table.get("dart").map(|v| v.clone())
+    //     } else {
+    //         None
+    //     }
+    // }
+
+    // fn update_from_ci(ci: &ComponentInterface) -> Vec<(String, Value)> {
+    //     vec![
+    //         (
+    //             "package_name".to_string(),
+    //             Value::String(ci.namespace().to_string()),
+    //         ),
+    //         (
+    //             "cdylib_name".to_string(),
+    //             Value::String(ci.namespace().to_string()),
+    //         ),
+    //     ]
+    // }
+    const TOML_KEY: &'static str = "dart";
+
+    fn update_from_ci(&mut self, ci: &ComponentInterface) {
+        self.cdylib_name
+            .get_or_insert_with(|| format!("uniffi_{}", ci.namespace()));
     }
 
-    fn get_config_defaults(ci: &ComponentInterface) -> Vec<(String, Value)> {
-        vec![
-            (
-                "package_name".to_string(),
-                Value::String(ci.namespace().to_string()),
-            ),
-            (
-                "cdylib_name".to_string(),
-                Value::String(ci.namespace().to_string()),
-            ),
-        ]
+    fn update_from_cdylib_name(&mut self, cdylib_name: &str) {
+        self.cdylib_name
+            .get_or_insert_with(|| cdylib_name.to_string());
     }
+
+    fn update_from_dependency_configs(&mut self, _config_map: HashMap<&str, &Self>) {}
 }
+
 pub struct BindingsGenerator {
     ci: ComponentInterface,
     config: Config,
@@ -403,9 +418,10 @@ fn get_config(
         Some(path) => {
             let contents = std::fs::read_to_string(&path)
                 .with_context(|| format!("Failed to read config file from {path}"))?;
-            let loaded_config: Config = toml::de::from_str(&contents)
+            let mut loaded_config: Config = toml::de::from_str(&contents)
                 .with_context(|| format!("Failed to generate config from file {path}"))?;
-            Ok(loaded_config.merge_with(&default_config))
+            loaded_config.update_from_ci(&ci);
+            Ok(loaded_config)
         }
         None => Ok(default_config),
     }

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -1,17 +1,19 @@
 use genco::prelude::*;
-use uniffi_bindgen::interface::{Enum, Method};
+use uniffi_bindgen::interface::Enum;
 
-use super::types::{
-    convert_from_rust_buffer, convert_to_rust_buffer, generate_ffi_dart_type, generate_ffi_type,
-    generate_type, type_lift_fn, type_lower_fn,
-};
-use super::utils::{class_name, fn_name, var_name};
+use super::utils::{class_name, enum_variant_name};
 
 pub fn generate_enum(obj: &Enum) -> dart::Tokens {
-    todo!();
     let cls_name = &class_name(obj.name());
-    quote! {
-        enum $cls_name {
+    if obj.is_flat() {
+        let variants =
+            quote!($(for variant in obj.variants() => $(enum_variant_name(variant.name())),));
+        quote! {
+            enum $cls_name {
+                $variants
+            }
         }
+    } else {
+        todo!("Add enum complex accociated types")
     }
 }

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -1,19 +1,36 @@
 use genco::prelude::*;
-use uniffi_bindgen::interface::Enum;
+use uniffi_bindgen::interface::{AsType, Enum};
 
-use super::utils::{class_name, enum_variant_name};
+use super::types::{
+    convert_from_rust_buffer, convert_to_rust_buffer, generate_ffi_dart_type, generate_ffi_type,
+    generate_type, type_lift_fn, type_lower_fn,
+};
+
+use super::utils::{class_name, enum_variant_name, var_name};
 
 pub fn generate_enum(obj: &Enum) -> dart::Tokens {
     let cls_name = &class_name(obj.name());
     if obj.is_flat() {
-        let variants =
-            quote!($(for variant in obj.variants() => $(enum_variant_name(variant.name())),));
         quote! {
             enum $cls_name {
-                $variants
+                $(for variant in obj.variants() => $(enum_variant_name(variant.name())),)
             }
         }
     } else {
-        todo!("Add enum complex accociated types")
+        quote! {
+            abstract class $cls_name {}
+
+            $(for variant in obj.variants()
+                => class $(class_name(variant.name()))$cls_name extends $cls_name {
+                        $(for field in variant.fields() => final $(generate_type(&field.as_type())) $(var_name(field.name()));  )
+
+                        $(class_name(variant.name()))$cls_name(
+                            $(for field in variant.fields() => this.$(var_name(field.name())),  )
+                        );
+                    }
+            )
+        }
+
+        //TODO!: Generate the lifting and lowering code for each variant
     }
 }

--- a/src/gen/functions.rs
+++ b/src/gen/functions.rs
@@ -1,5 +1,5 @@
 use genco::prelude::*;
-use uniffi_bindgen::interface::Function;
+use uniffi_bindgen::interface::{AsType, Function};
 
 use super::types::{
     convert_from_rust_buffer, convert_to_rust_buffer, generate_ffi_dart_type, generate_ffi_type,
@@ -11,12 +11,12 @@ use super::utils::{fn_name, var_name};
 pub fn generate_function(api: &str, fun: &Function) -> dart::Tokens {
     let ffi = fun.ffi_func();
     let fn_name = fn_name(fun.name());
-    let args = quote!($(for arg in &fun.arguments() => $(generate_type(arg.type_())) $(var_name(arg.name())),));
+    let args = quote!($(for arg in &fun.arguments() => $(generate_type(&arg.as_type())) $(var_name(arg.name())),));
     let ff_name = ffi.name();
     let inner = quote! {
     rustCall(api, (res) =>
         _$(&fn_name)(
-            $(for arg in &fun.arguments() => $(convert_to_rust_buffer(arg.type_(), type_lower_fn(arg.type_(), quote!($(var_name(arg.name())))))),)
+            $(for arg in &fun.arguments() => $(convert_to_rust_buffer(&arg.as_type(), type_lower_fn(&arg.as_type(), quote!($(var_name(arg.name())))))),)
         res)
     )
     };

--- a/src/gen/objects.rs
+++ b/src/gen/objects.rs
@@ -1,5 +1,5 @@
 use genco::prelude::*;
-use uniffi_bindgen::interface::{Method, Object};
+use uniffi_bindgen::interface::{AsType, Method, Object};
 
 use super::types::{
     convert_from_rust_buffer, convert_to_rust_buffer, generate_ffi_dart_type, generate_ffi_type,
@@ -38,13 +38,13 @@ pub fn generate_method(fun: &Method) -> dart::Tokens {
     let api = "_api";
     let ffi = fun.ffi_func();
     let fn_name = fn_name(fun.name());
-    let args = quote!($(for arg in &fun.arguments() => $(generate_type(arg.type_())) $(var_name(arg.name())),));
+    let args = quote!($(for arg in &fun.arguments() => $(generate_type(&arg.as_type())) $(var_name(arg.name())),));
     let ff_name = ffi.name();
     let inner = quote! {
     rustCall(api, (res) =>
         _$(&fn_name)(
             _ptr,
-            $(for arg in &fun.arguments() => $(convert_to_rust_buffer(arg.type_(), type_lower_fn(arg.type_(), quote!($(var_name(arg.name())))))),)
+            $(for arg in &fun.arguments() => $(convert_to_rust_buffer(&arg.as_type(), type_lower_fn(&arg.as_type(), quote!($(var_name(arg.name())))))),)
         res)
     )
     };

--- a/src/gen/primitives.rs
+++ b/src/gen/primitives.rs
@@ -1,8 +1,8 @@
 use paste::paste;
-use uniffi_bindgen::backend::{CodeOracle, CodeType, Literal};
-use uniffi_bindgen::interface::{types::Type, Radix};
+use uniffi_bindgen::backend::{CodeType, Literal};
+use uniffi_bindgen::interface::{Radix, Type};
 
-fn render_literal(_oracle: &dyn CodeOracle, literal: &Literal) -> String {
+fn render_literal(literal: &Literal) -> String {
     fn typed_number(type_: &Type, num_str: String) -> String {
         match type_ {
             Type::Int8
@@ -50,12 +50,12 @@ macro_rules! impl_code_type_for_primitive {
             pub struct $T;
 
             impl CodeType for $T  {
-                fn type_label(&self, _oracle: &dyn CodeOracle) -> String {
+                fn type_label(&self,) -> String {
                     $class_name.into()
                 }
 
-                fn literal(&self, oracle: &dyn CodeOracle, literal: &Literal) -> String {
-                    render_literal(oracle, &literal)
+                fn literal(&self, literal: &Literal) -> String {
+                    render_literal(&literal)
                 }
             }
         }

--- a/src/gen/records.rs
+++ b/src/gen/records.rs
@@ -1,5 +1,5 @@
 use genco::prelude::*;
-use uniffi_bindgen::interface::{Method, Record};
+use uniffi_bindgen::interface::{AsType, Method, Record};
 
 use super::types::{
     convert_from_rust_buffer, convert_to_rust_buffer, generate_ffi_dart_type, generate_ffi_type,
@@ -11,7 +11,7 @@ pub fn generate_record(obj: &Record) -> dart::Tokens {
     let cls_name = &class_name(obj.name());
     quote! {
         class $cls_name {
-            $(for f in obj.fields() => final $(generate_type(f.type_())) $(var_name(f.name()));)
+            $(for f in obj.fields() => final $(generate_type(&f.as_type())) $(var_name(f.name()));)
 
             $(cls_name)._($(for f in obj.fields() => this.$(var_name(f.name())), ));
 

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -61,6 +61,9 @@ pub fn generate_type(ty: &Type) -> dart::Tokens {
         Type::Object{name, ..} => quote!($name),
         Type::Boolean => quote!(bool),
         Type::Optional{ inner_type} => quote!($(generate_type(inner_type))?),
+        Type::Sequence { inner_type } => quote!(List<$(generate_type(inner_type))>),
+        Type::Enum { name,..  } => quote!($name),
+        Type::Record { name,..  } => quote!($name),
         _ => todo!("Type::{:?}", ty)
         // AbiType::Num(ty) => self.generate_wrapped_num_type(*ty),
         // AbiType::Isize | AbiType::Usize => quote!(int),
@@ -123,8 +126,8 @@ pub fn type_lift_fn(ty: &Type, inner: dart::Tokens) -> dart::Tokens {
         Type::Object { name, .. } => quote!($name.lift(api, $inner)),
         Type::Optional { inner_type } => {
             // TODO!: Fix optional type generation!
-            todo!("Lift optional not implimented");
-            //quote!(liftOptional(api, $inner, (api, v) => $(type_lift_fn(o, quote!(v)))))
+            //todo!("Lift optional not implimented");
+            quote!(liftOptional(api, $inner, (api, v) => $(type_lift_fn(o, quote!(v)))))
         }
         _ => todo!("lift Type::{:?}", ty),
     }

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -58,9 +58,9 @@ pub fn generate_type(ty: &Type) -> dart::Tokens {
         | Type::Float32
         | Type::Float64 => quote!(int),
         Type::String => quote!(String),
-        Type::Object(name) => quote!($name),
+        Type::Object{name, ..} => quote!($name),
         Type::Boolean => quote!(bool),
-        Type::Optional(inner) => quote!($(generate_type(inner))?),
+        Type::Optional{ inner_type} => quote!($(generate_type(inner_type))?),
         _ => todo!("Type::{:?}", ty)
         // AbiType::Num(ty) => self.generate_wrapped_num_type(*ty),
         // AbiType::Isize | AbiType::Usize => quote!(int),
@@ -92,16 +92,16 @@ pub fn generate_type(ty: &Type) -> dart::Tokens {
 
 pub fn convert_from_rust_buffer(ty: &Type, inner: dart::Tokens) -> dart::Tokens {
     match ty {
-        Type::Object(_) => inner,
-        Type::String | Type::Optional(_) => quote!($(inner).toIntList()),
+        Type::Object { .. } => inner,
+        Type::String | Type::Optional { .. } => quote!($(inner).toIntList()),
         _ => inner,
     }
 }
 
 pub fn convert_to_rust_buffer(ty: &Type, inner: dart::Tokens) -> dart::Tokens {
     match ty {
-        Type::Object(_) => inner,
-        Type::String | Type::Optional(_) => quote!(toRustBuffer(api, $inner)),
+        Type::Object { .. } => inner,
+        Type::String | Type::Optional { .. } => quote!(toRustBuffer(api, $inner)),
         _ => inner,
     }
 }
@@ -120,9 +120,11 @@ pub fn type_lift_fn(ty: &Type, inner: dart::Tokens) -> dart::Tokens {
         | Type::Float64 => inner,
         Type::Boolean => quote!(($inner) > 0),
         Type::String => quote!(liftString(api, $inner)),
-        Type::Object(name) => quote!($name.lift(api, $inner)),
-        Type::Optional(o) => {
-            quote!(liftOptional(api, $inner, (api, v) => $(type_lift_fn(o, quote!(v)))))
+        Type::Object { name, .. } => quote!($name.lift(api, $inner)),
+        Type::Optional { inner_type } => {
+            // TODO!: Fix optional type generation!
+            todo!("Lift optional not implimented");
+            //quote!(liftOptional(api, $inner, (api, v) => $(type_lift_fn(o, quote!(v)))))
         }
         _ => todo!("lift Type::{:?}", ty),
     }
@@ -142,9 +144,11 @@ pub fn type_lower_fn(ty: &Type, inner: dart::Tokens) -> dart::Tokens {
         | Type::Float64
         | Type::Boolean => inner,
         Type::String => quote!(lowerString(api, $inner)),
-        Type::Object(name) => quote!($name.lower(api, $inner)),
-        Type::Optional(o) => {
-            quote!(lowerOptional(api, $inner, (api, v) => $(type_lower_fn(o, quote!(v)))))
+        Type::Object { name, .. } => quote!($name.lower(api, $inner)),
+        Type::Optional { inner_type } => {
+            // TODO!: Fix optional type generation!
+            todo!("Lift optional not implimented");
+            //quote!(lowerOptional(api, $inner, (api, v) => $(type_lower_fn(o, quote!(v)))))
         }
         _ => todo!("lower Type::{:?}", ty),
     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,6 +1,6 @@
 use crate::gen;
 use anyhow::{bail, Result};
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use std::fs::{copy, create_dir_all, File};
 use std::io::Write;
 use std::process::Command;
@@ -8,45 +8,57 @@ use std::thread;
 use std::time::Duration;
 use uniffi_testing::UniFFITestHelper;
 
-pub fn run_test(fixture: &str) -> Result<()> {
+// A source to compile for a test
+#[derive(Debug)]
+pub struct CompileSource {
+    pub udl_path: Utf8PathBuf,
+    pub config_path: Option<Utf8PathBuf>,
+}
+
+pub fn run_test(fixture: &str, udl_path: &str, config_path: Option<&str>) -> Result<()> {
     let tmp_dir = camino_tempfile::tempdir()?;
 
     let script_path = Utf8Path::new(".").canonicalize_utf8()?;
     let test_helper = UniFFITestHelper::new(fixture)?;
     let out_dir = test_helper.create_out_dir(&tmp_dir, &script_path)?;
 
+    let udl_path = Utf8Path::new(".").canonicalize_utf8()?.join(udl_path);
+    let config_path = if let Some(path) = config_path {
+        Some(Utf8Path::new(".").canonicalize_utf8()?.join(path))
+    } else {
+        None
+    };
+
     println!("{out_dir}");
 
     let mut pubspec = File::create(out_dir.join("pubspec.yaml"))?;
     pubspec.write(
         b"
-name: uniffi_test
-description: testing module for uniffi
-version: 1.0.0
+    name: uniffi_test
+    description: testing module for uniffi
+    version: 1.0.0
 
-environment:
-  sdk: '>=2.19.6 <3.0.0'
-dev_dependencies:
-  test: ^1.24.3
-dependencies:
-  ffi: ^2.0.1
-",
+    environment:
+      sdk: '>=2.19.6 <3.0.0'
+    dev_dependencies:
+      test: ^1.24.3
+    dependencies:
+      ffi: ^2.0.1
+    ",
     )?;
     pubspec.flush()?;
     let test_outdir = out_dir.join("test");
     create_dir_all(&test_outdir)?;
 
-    test_helper.copy_cdylibs_to_out_dir(&out_dir)?;
-    for source in test_helper.get_compile_sources()? {
-        gen::generate_dart_bindings(
-            &source.udl_path,
-            source.config_path.as_deref(),
-            Some(&out_dir),
-            Some(&test_helper.cdylib_path()?),
-        )?;
-    }
-    // let generated_sources =
-    //     GeneratedSources::new(&test_helper.cdylib_path()?, &out_dir, &test_helper)?;
+    test_helper.copy_cdylib_to_out_dir(&out_dir)?;
+    gen::generate_dart_bindings(
+        &udl_path,
+        config_path.as_deref(),
+        Some(&out_dir),
+        Some(&test_helper.cdylib_path()?),
+    )?;
+    //     // let generated_sources =
+    //     //     GeneratedSources::new(&test_helper.cdylib_path()?, &out_dir, &test_helper)?;
     for file in glob::glob(&format!("**/*.dart"))?.filter_map(Result::ok) {
         copy(
             &file,
@@ -60,8 +72,12 @@ dependencies:
     let status = command.spawn()?.wait()?;
     if !status.success() {
         println!("FAILED");
-        thread::sleep(Duration::from_secs(60));
+        thread::sleep(Duration::from_secs(120));
         bail!("running `dart` to run test script failed ({:?})", command);
     }
     Ok(())
+}
+
+pub fn get_compile_sources() -> Result<Vec<CompileSource>> {
+    todo!("Not implimented")
 }


### PR DESCRIPTION
### Adding Dart Enum Generation and Lifting for Numeric Types in Option
I've added enum generation for flat and complex associated types and lifting for Dart numeric types `int` and `double` out of the Rust `Option<T>` type.


#### Next Steps
- Finish lifting and lowering for enums
- Add extra tests to make sure things work