### PR TITLE
Chavic/enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,6 @@ path = "src/bin.rs"
 required-features = ["binary"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[patch.crates-io]
-proc-macro2 = "1.0.66"
-
 [dependencies]
 anyhow = "1"
 paste = "1"
@@ -42,6 +39,7 @@ camino = "1"
 serde = "1"
 toml = "0.5"
 genco = "0.17.5"
+proc-macro2 = "1.0.66"
 
 # feature specific stuff
 uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "8565b7f941e7967778efd39c5ab27551dfa23ec6", optional = true }

--- a/fixtures/large_enum/src/lib.rs
+++ b/fixtures/large_enum/src/lib.rs
@@ -31,47 +31,24 @@ pub fn new_bool_value(value: bool) -> Value {
     Value::Bool { value }
 }
 
-// #[uniffi::export]
-// pub fn new_i64_value(value: i64) -> Value {
-//     Value::I64 { value }
-// }
+#[uniffi::export]
+pub fn take_value(value: Value) -> String {
+    match value {
+        Value::String { value } => format!("{}",value),
+        Value::Bool { value } => format!("{}",value),
+        Value::U8 { value } => format!("{}",value),
+        Value::U16 { value } => format!("{}",value),
+        Value::U32 { value } => format!("{}",value),
+        Value::U64 { value } => format!("{}",value),
+        Value::I8 { value } => format!("{}",value),
+        Value::I16 { value } => format!("{}",value),
+        Value::I32 { value } => format!("{}",value),
+        Value::I64 { value }  => format!("{}",value),
+       // Value::Enum { discriminator, fields } => format!("{}",value),
+    }
+}
 
-// #[uniffi::export]
-// pub fn new_u64_value(value: u64) -> Value {
-//     Value::U64 { value }
-// }
-
-// #[uniffi::export]
-// pub fn new_i64_value(value: i64) -> Value {
-//     Value::I64 { value }
-// }
-// #[uniffi::export]
-// pub fn new_u64_value(value: u64) -> Value {
-//     Value::U64 { value }
-// }
-
-// #[uniffi::export]
-// pub fn new_i64_value(value: i64) -> Value {
-//     Value::I64 { value }
-// }
-
-// #[uniffi::export]
-// pub fn take_value(value: Value)  {
-//     match value {
-//         Value::String { value } => todo!(),
-//         Value::Bool { value } => todo!(),
-//         Value::U8 { value } => todo!(),
-//         Value::U16 { value } => todo!(),
-//         Value::U32 { value } => todo!(),
-//         Value::U64 { value } => todo!(),
-//         Value::I8 { value } => todo!(),
-//         Value::I16 { value } => todo!(),
-//         Value::I32 { value } => todo!(),
-//         Value::I64 { value } => todo!(),
-//        // Value::Enum { discriminator, fields } => todo!(),
-//     }
-// }
-
+// TODO: Add floats and Collections (Maps, Vector, ...)
 #[derive(Debug, Clone, Enum)]
 pub enum Value {
     String {

--- a/fixtures/large_enum/src/lib.rs
+++ b/fixtures/large_enum/src/lib.rs
@@ -53,6 +53,16 @@ pub fn new_i32_value(value: i32) -> Value {
 }
 
 #[uniffi::export]
+pub fn new_f32_value(value: f32) -> Value {
+    Value::F32 { value }
+}
+
+#[uniffi::export]
+pub fn new_f64_value(value: f64) -> Value {
+    Value::F64 { value }
+}
+
+#[uniffi::export]
 pub fn new_string_value(value: String) -> Value {
     Value::String { value }
 }
@@ -75,6 +85,8 @@ pub fn take_value(value: Value) -> String {
         Value::I16 { value } => format!("{}",value),
         Value::I32 { value } => format!("{}",value),
         Value::I64 { value }  => format!("{}",value),
+        Value::F32 { value }  => format!("{}",value),
+        Value::F64 { value }  => format!("{}",value),
        // Value::Enum { discriminator, fields } => format!("{}",value),
     }
 }
@@ -87,7 +99,7 @@ pub enum FlatEnum {
     Four
 }
 
-// TODO: Add floats and Collections (Maps, Vector, ...)
+// TODO: Add Collections (Maps, Vector, ...)
 #[derive(Debug, Clone, Enum)]
 pub enum Value {
     String {
@@ -121,6 +133,12 @@ pub enum Value {
     I64 {
         value: i64,
     },
+    F32 {
+        value: f32,
+    },
+    F64 {
+        value: f64
+    }
     // Enum {
     //     discriminator: u8,
     //     fields: Vec<Value>,

--- a/fixtures/large_enum/src/lib.rs
+++ b/fixtures/large_enum/src/lib.rs
@@ -33,6 +33,26 @@ pub fn take_flat_enum(flat: FlatEnum) -> String {
 }
 
 #[uniffi::export]
+pub fn new_u8_value(value: u8) -> Value {
+    Value::U8 { value }
+}
+
+#[uniffi::export]
+pub fn new_i8_value(value: i8) -> Value {
+    Value::I8 { value }
+}
+
+#[uniffi::export]
+pub fn new_u16_value(value: u16) -> Value {
+    Value::U16 { value }
+}
+
+#[uniffi::export]
+pub fn new_i16_value(value: i16) -> Value {
+    Value::I16 { value }
+}
+
+#[uniffi::export]
 pub fn new_u64_value(value: u64) -> Value {
     Value::U64 { value }
 }

--- a/fixtures/large_enum/src/lib.rs
+++ b/fixtures/large_enum/src/lib.rs
@@ -1,128 +1,76 @@
+use uniffi;
 use uniffi::{Enum, Record};
 
-#[derive(Clone, Debug, Enum)]
-pub enum Instruction {
-    CallMethod1 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod2 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod3 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod4 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod5 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod6 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod10 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod11 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod12 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod13 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod14 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod15 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod16 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod17 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod18 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod19 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod20 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod21 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod22 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod23 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod24 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod25 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod26 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
-    CallMethod27 {
-        object: Value,
-        method_name: Value,
-        args: Value,
-    },
+#[uniffi::export]
+pub fn new_u64_value(value: u64) -> Value {
+    Value::U64 { value }
 }
+
+#[uniffi::export]
+pub fn new_i64_value(value: i64) -> Value {
+    Value::I64 { value }
+}
+
+#[uniffi::export]
+pub fn new_u32_value(value: u32) -> Value {
+    Value::U32 { value }
+}
+
+#[uniffi::export]
+pub fn new_i32_value(value: i32) -> Value {
+    Value::I32 { value }
+}
+
+#[uniffi::export]
+pub fn new_string_value(value: String) -> Value {
+    Value::String { value }
+}
+
+#[uniffi::export]
+pub fn new_bool_value(value: bool) -> Value {
+    Value::Bool { value }
+}
+
+// #[uniffi::export]
+// pub fn new_i64_value(value: i64) -> Value {
+//     Value::I64 { value }
+// }
+
+// #[uniffi::export]
+// pub fn new_u64_value(value: u64) -> Value {
+//     Value::U64 { value }
+// }
+
+// #[uniffi::export]
+// pub fn new_i64_value(value: i64) -> Value {
+//     Value::I64 { value }
+// }
+// #[uniffi::export]
+// pub fn new_u64_value(value: u64) -> Value {
+//     Value::U64 { value }
+// }
+
+// #[uniffi::export]
+// pub fn new_i64_value(value: i64) -> Value {
+//     Value::I64 { value }
+// }
+
+// #[uniffi::export]
+// pub fn take_value(value: Value)  {
+//     match value {
+//         Value::String { value } => todo!(),
+//         Value::Bool { value } => todo!(),
+//         Value::U8 { value } => todo!(),
+//         Value::U16 { value } => todo!(),
+//         Value::U32 { value } => todo!(),
+//         Value::U64 { value } => todo!(),
+//         Value::I8 { value } => todo!(),
+//         Value::I16 { value } => todo!(),
+//         Value::I32 { value } => todo!(),
+//         Value::I64 { value } => todo!(),
+//        // Value::Enum { discriminator, fields } => todo!(),
+//     }
+// }
 
 #[derive(Debug, Clone, Enum)]
 pub enum Value {
@@ -132,7 +80,6 @@ pub enum Value {
     Bool {
         value: bool,
     },
-
     U8 {
         value: u8,
     },
@@ -158,25 +105,25 @@ pub enum Value {
     I64 {
         value: i64,
     },
-    Enum {
-        discriminator: u8,
-        fields: Vec<Value>,
-    },
-    NonHomogenousCollection {
-        elements: Vec<Value>,
-    },
-    HomogenousCollection {
-        elements: Vec<Value>,
-    },
-    Map {
-        entries: Vec<MapEntry>,
-    },
-    PublicKey {
-        value: Vec<u8>,
-    },
-    Signature {
-        value: Vec<u8>,
-    },
+    // Enum {
+    //     discriminator: u8,
+    //     fields: Vec<Value>,
+    // },
+    // NonHomogenousCollection {
+    //     elements: Vec<Value>,
+    // },
+    // HomogenousCollection {
+    //     elements: Vec<Value>,
+    // },
+    // Map {
+    //     entries: Vec<MapEntry>,
+    // },
+    // PublicKey {
+    //     value: Vec<u8>,
+    // },
+    // Signature {
+    //     value: Vec<u8>,
+    // },
 }
 
 #[derive(Clone, Debug, Record)]

--- a/fixtures/large_enum/src/lib.rs
+++ b/fixtures/large_enum/src/lib.rs
@@ -1,6 +1,37 @@
 use uniffi;
 use uniffi::{Enum, Record};
 
+
+#[uniffi::export]
+pub fn new_flat_one() -> FlatEnum {
+    FlatEnum::One
+}
+
+#[uniffi::export]
+pub fn new_flat_two() -> FlatEnum {
+    FlatEnum::Two
+}
+
+#[uniffi::export]
+pub fn new_flat_three() -> FlatEnum {
+    FlatEnum::Three
+}
+
+#[uniffi::export]
+pub fn new_flat_four() -> FlatEnum {
+    FlatEnum::Four
+}
+
+#[uniffi::export]
+pub fn take_flat_enum(flat: FlatEnum) -> String {
+    match flat {
+        FlatEnum::One => "One".to_string(),
+        FlatEnum::Two => "Two".to_string(),
+        FlatEnum::Three => "Three".to_string(),
+        FlatEnum::Four => "Four".to_string(),
+    }
+}
+
 #[uniffi::export]
 pub fn new_u64_value(value: u64) -> Value {
     Value::U64 { value }
@@ -46,6 +77,14 @@ pub fn take_value(value: Value) -> String {
         Value::I64 { value }  => format!("{}",value),
        // Value::Enum { discriminator, fields } => format!("{}",value),
     }
+}
+
+#[derive(Debug, Clone, Enum)]
+pub enum FlatEnum {
+    One, 
+    Two, 
+    Three, 
+    Four
 }
 
 // TODO: Add floats and Collections (Maps, Vector, ...)

--- a/fixtures/large_enum/test/large_enum_test.dart
+++ b/fixtures/large_enum/test/large_enum_test.dart
@@ -24,12 +24,16 @@ void main() {
   // Testing the complex associative types...
   final inner_value = 84646234643264;
   final inner_value2 = 846;
+  final inner_value_double = 643264.84646234;
+  final inner_value_float = 84.68;
   final inner_bool = true;
-  // TODO: Add floats and Collections (Maps, Vector, ...)
+  // TODO: Add u8, i8, u16, i16, and Collections (Maps, Vector, ...)
   U32Value u32Value = (api.newU32Value(inner_value2) as U32Value);
   U64Value u64Value = (api.newU64Value(inner_value) as U64Value);
   I64Value i64Value = (api.newI64Value(inner_value) as I64Value);
   I32Value i32Value = (api.newI32Value(inner_value2) as I32Value);
+  F32Value f32Value = (api.newF32Value(inner_value_float) as F32Value);
+  F64Value f64Value = (api.newF64Value(inner_value_double) as F64Value);
   // TODO: Cover Floats and Doubles
   StringValue stringValue =
       (api.newStringValue(inner_value.toString()) as StringValue);
@@ -41,7 +45,10 @@ void main() {
     expect(i64Value.value, inner_value);
     expect(u64Value.value, inner_value);
     expect(i32Value.value, inner_value2);
-    // TODO: Cover Floats and Doubles
+    // Comparing floats is a little tricky, but it can be done within a certain precision
+    expect(true, (f32Value.value - inner_value_float).abs() < 1e-3);
+    expect(true, (f64Value.value - inner_value_double).abs() < 1e-10);
+
     expect(stringValue.value, inner_value.toString());
     expect(boolValue.value, inner_bool);
   });
@@ -52,7 +59,9 @@ void main() {
     expect(api.takeValue(i64Value), inner_value.toString());
     expect(api.takeValue(u64Value), inner_value.toString());
     expect(api.takeValue(i32Value), inner_value2.toString());
-    // TODO: Cover Floats and Doubles
+    expect(api.takeValue(f32Value), inner_value_float.toString());
+    expect(api.takeValue(f64Value), inner_value_double.toString());
+
     expect(api.takeValue(stringValue), inner_value.toString());
     expect(api.takeValue(boolValue), inner_bool.toString());
   });

--- a/fixtures/large_enum/test/large_enum_test.dart
+++ b/fixtures/large_enum/test/large_enum_test.dart
@@ -30,7 +30,7 @@ void main() {
   U64Value u64Value = (api.newU64Value(inner_value) as U64Value);
   I64Value i64Value = (api.newI64Value(inner_value) as I64Value);
   I32Value i32Value = (api.newI32Value(inner_value2) as I32Value);
-
+  // TODO: Cover Floats and Doubles
   StringValue stringValue =
       (api.newStringValue(inner_value.toString()) as StringValue);
   BoolValue boolValue = (api.newBoolValue(inner_bool) as BoolValue);
@@ -41,19 +41,19 @@ void main() {
     expect(i64Value.value, inner_value);
     expect(u64Value.value, inner_value);
     expect(i32Value.value, inner_value2);
-
+    // TODO: Cover Floats and Doubles
     expect(stringValue.value, inner_value.toString());
     expect(boolValue.value, inner_bool);
   });
 
-  // test('Passing Down/Lowering Complex Enums', () {
-  //   // Can we pass the value down to rust correctly?
-  //   expect(api.takeValue(u32Value), inner_value2.toString());
-  //   expect(api.takeValue(i64Value), inner_value.toString());
-  //   expect(api.takeValue(u64Value), inner_value.toString());
-  //   expect(api.takeValue(i32Value), inner_value2.toString());
-
-  //   // expect(api.takeValue(stringValue), inner_value.toString());
-  //   expect(api.takeValue(boolValue), inner_bool.toString());
-  // });
+  test('Passing Down/Lowering Complex Enums', () {
+    // Can we pass the value down to rust correctly?
+    expect(api.takeValue(u32Value), inner_value2.toString());
+    expect(api.takeValue(i64Value), inner_value.toString());
+    expect(api.takeValue(u64Value), inner_value.toString());
+    expect(api.takeValue(i32Value), inner_value2.toString());
+    // TODO: Cover Floats and Doubles
+    //expect(api.takeValue(stringValue), inner_value.toString());
+    expect(api.takeValue(boolValue), inner_bool.toString());
+  });
 }

--- a/fixtures/large_enum/test/large_enum_test.dart
+++ b/fixtures/large_enum/test/large_enum_test.dart
@@ -5,7 +5,7 @@ void main() {
   final api = Api.load();
 
   // Testing flat enums
-  test('Creating/Lifting Enums', () {
+  test('Creating/Lifting Flat Enums', () {
     // Do we get the expected enum
     expect(FlatEnum.one, api.newFlatOne());
     expect(FlatEnum.two, api.newFlatTwo());
@@ -13,7 +13,7 @@ void main() {
     expect(FlatEnum.four, api.newFlatFour());
   });
 
-  test('Passing Down/Lowering Enums', () {
+  test('Passing Down/Lowering Flat Enums', () {
     // Can we pass the value down to rust correctly?
     expect(api.takeFlatEnum(FlatEnum.one), "One");
     expect(api.takeFlatEnum(FlatEnum.two), "Two");
@@ -35,7 +35,7 @@ void main() {
       (api.newStringValue(inner_value.toString()) as StringValue);
   BoolValue boolValue = (api.newBoolValue(inner_bool) as BoolValue);
 
-  test('Creating/Lifting Enums', () {
+  test('Creating/Lifting Complex Enums', () {
     // Do we get the expected inner value? Correctly.
     expect(u32Value.value, inner_value2);
     expect(i64Value.value, inner_value);
@@ -46,14 +46,14 @@ void main() {
     expect(boolValue.value, inner_bool);
   });
 
-  test('Passing Down/Lowering Enums', () {
-    // Can we pass the value down to rust correctly?
-    expect(api.takeValue(u32Value), inner_value2.toString());
-    expect(api.takeValue(i64Value), inner_value.toString());
-    expect(api.takeValue(u64Value), inner_value.toString());
-    expect(api.takeValue(i32Value), inner_value2.toString());
+  // test('Passing Down/Lowering Complex Enums', () {
+  //   // Can we pass the value down to rust correctly?
+  //   expect(api.takeValue(u32Value), inner_value2.toString());
+  //   expect(api.takeValue(i64Value), inner_value.toString());
+  //   expect(api.takeValue(u64Value), inner_value.toString());
+  //   expect(api.takeValue(i32Value), inner_value2.toString());
 
-    expect(api.takeValue(stringValue), inner_value.toString());
-    expect(api.takeValue(boolValue), inner_bool.toString());
-  });
+  //   // expect(api.takeValue(stringValue), inner_value.toString());
+  //   expect(api.takeValue(boolValue), inner_bool.toString());
+  // });
 }

--- a/fixtures/large_enum/test/large_enum_test.dart
+++ b/fixtures/large_enum/test/large_enum_test.dart
@@ -22,25 +22,37 @@ void main() {
   });
 
   // Testing the complex associative types...
+  final inner_value_small =
+      127; // Can go beyond the max for 8bits, -127 to 127 for Int and 255 for UInt
   final inner_value = 84646234643264;
   final inner_value2 = 846;
   final inner_value_double = 643264.84646234;
   final inner_value_float = 84.68;
   final inner_bool = true;
-  // TODO: Add u8, i8, u16, i16, and Collections (Maps, Vector, ...)
+  // TODO: Collections (Maps, Vector, ...)
+  U8Value u8Value = (api.newU8Value(inner_value_small) as U8Value);
+  U16Value u16Value = (api.newU16Value(inner_value2) as U16Value);
+  I8Value i8Value = (api.newI8Value(inner_value_small) as I8Value);
+  I16Value i16Value = (api.newI16Value(inner_value2) as I16Value);
+
   U32Value u32Value = (api.newU32Value(inner_value2) as U32Value);
   U64Value u64Value = (api.newU64Value(inner_value) as U64Value);
   I64Value i64Value = (api.newI64Value(inner_value) as I64Value);
   I32Value i32Value = (api.newI32Value(inner_value2) as I32Value);
   F32Value f32Value = (api.newF32Value(inner_value_float) as F32Value);
   F64Value f64Value = (api.newF64Value(inner_value_double) as F64Value);
-  // TODO: Cover Floats and Doubles
+
   StringValue stringValue =
       (api.newStringValue(inner_value.toString()) as StringValue);
   BoolValue boolValue = (api.newBoolValue(inner_bool) as BoolValue);
 
   test('Creating/Lifting Complex Enums', () {
     // Do we get the expected inner value? Correctly.
+    expect(u8Value.value, inner_value_small);
+    expect(u16Value.value, inner_value2);
+    expect(i8Value.value, inner_value_small);
+    expect(i16Value.value, inner_value2);
+
     expect(u32Value.value, inner_value2);
     expect(i64Value.value, inner_value);
     expect(u64Value.value, inner_value);
@@ -55,6 +67,10 @@ void main() {
 
   test('Passing Down/Lowering Complex Enums', () {
     // Can we pass the value down to rust correctly?
+    expect(api.takeValue(u8Value), inner_value_small.toString());
+    expect(api.takeValue(u16Value), inner_value2.toString());
+    expect(api.takeValue(i8Value), inner_value_small.toString());
+    expect(api.takeValue(i16Value), inner_value2.toString());
     expect(api.takeValue(u32Value), inner_value2.toString());
     expect(api.takeValue(i64Value), inner_value.toString());
     expect(api.takeValue(u64Value), inner_value.toString());

--- a/fixtures/large_enum/test/large_enum_test.dart
+++ b/fixtures/large_enum/test/large_enum_test.dart
@@ -4,6 +4,24 @@ import '../large_enum.dart';
 void main() {
   final api = Api.load();
 
+  // Testing flat enums
+  test('Creating/Lifting Enums', () {
+    // Do we get the expected enum
+    expect(FlatEnum.one, api.newFlatOne());
+    expect(FlatEnum.two, api.newFlatTwo());
+    expect(FlatEnum.three, api.newFlatThree());
+    expect(FlatEnum.four, api.newFlatFour());
+  });
+
+  test('Passing Down/Lowering Enums', () {
+    // Can we pass the value down to rust correctly?
+    expect(api.takeFlatEnum(FlatEnum.one), "One");
+    expect(api.takeFlatEnum(FlatEnum.two), "Two");
+    expect(api.takeFlatEnum(FlatEnum.three), "Three");
+    expect(api.takeFlatEnum(FlatEnum.four), "Four");
+  });
+
+  // Testing the complex associative types...
   final inner_value = 84646234643264;
   final inner_value2 = 846;
   final inner_bool = true;
@@ -28,14 +46,14 @@ void main() {
     expect(boolValue.value, inner_bool);
   });
 
-  test('Passing Down/Lowering Enums', () {
-    // Can we pass the value down to rust correctly?
-    expect(api.takeValue(u32Value), inner_value2.toString());
-    expect(api.takeValue(i64Value), inner_value.toString());
-    expect(api.takeValue(u64Value), inner_value.toString());
-    expect(api.takeValue(i32Value), inner_value2.toString());
+  // test('Passing Down/Lowering Enums', () {
+  //   // Can we pass the value down to rust correctly?
+  //   expect(api.takeValue(u32Value), inner_value2.toString());
+  //   expect(api.takeValue(i64Value), inner_value.toString());
+  //   expect(api.takeValue(u64Value), inner_value.toString());
+  //   expect(api.takeValue(i32Value), inner_value2.toString());
 
-    expect(api.takeValue(stringValue), inner_value.toString());
-    expect(api.takeValue(boolValue), inner_bool.toString());
-  });
+  //   expect(api.takeValue(stringValue), inner_value.toString());
+  //   expect(api.takeValue(boolValue), inner_bool.toString());
+  // });
 }

--- a/fixtures/large_enum/test/large_enum_test.dart
+++ b/fixtures/large_enum/test/large_enum_test.dart
@@ -53,7 +53,7 @@ void main() {
     expect(api.takeValue(u64Value), inner_value.toString());
     expect(api.takeValue(i32Value), inner_value2.toString());
     // TODO: Cover Floats and Doubles
-    //expect(api.takeValue(stringValue), inner_value.toString());
+    expect(api.takeValue(stringValue), inner_value.toString());
     expect(api.takeValue(boolValue), inner_bool.toString());
   });
 }

--- a/fixtures/large_enum/test/large_enum_test.dart
+++ b/fixtures/large_enum/test/large_enum_test.dart
@@ -46,14 +46,14 @@ void main() {
     expect(boolValue.value, inner_bool);
   });
 
-  // test('Passing Down/Lowering Enums', () {
-  //   // Can we pass the value down to rust correctly?
-  //   expect(api.takeValue(u32Value), inner_value2.toString());
-  //   expect(api.takeValue(i64Value), inner_value.toString());
-  //   expect(api.takeValue(u64Value), inner_value.toString());
-  //   expect(api.takeValue(i32Value), inner_value2.toString());
+  test('Passing Down/Lowering Enums', () {
+    // Can we pass the value down to rust correctly?
+    expect(api.takeValue(u32Value), inner_value2.toString());
+    expect(api.takeValue(i64Value), inner_value.toString());
+    expect(api.takeValue(u64Value), inner_value.toString());
+    expect(api.takeValue(i32Value), inner_value2.toString());
 
-  //   expect(api.takeValue(stringValue), inner_value.toString());
-  //   expect(api.takeValue(boolValue), inner_bool.toString());
-  // });
+    expect(api.takeValue(stringValue), inner_value.toString());
+    expect(api.takeValue(boolValue), inner_bool.toString());
+  });
 }

--- a/fixtures/large_enum/test/large_enum_test.dart
+++ b/fixtures/large_enum/test/large_enum_test.dart
@@ -4,21 +4,21 @@ import '../large_enum.dart';
 void main() {
   final api = Api.load();
 
+  final inner_value = 84646234643264;
+  final inner_value2 = 846;
+  final inner_bool = true;
+  // TODO: Add floats and Collections (Maps, Vector, ...)
+  U32Value u32Value = (api.newU32Value(inner_value2) as U32Value);
+  U64Value u64Value = (api.newU64Value(inner_value) as U64Value);
+  I64Value i64Value = (api.newI64Value(inner_value) as I64Value);
+  I32Value i32Value = (api.newI32Value(inner_value2) as I32Value);
+
+  StringValue stringValue =
+      (api.newStringValue(inner_value.toString()) as StringValue);
+  BoolValue boolValue = (api.newBoolValue(inner_bool) as BoolValue);
+
   test('Creating/Lifting Enums', () {
     // Do we get the expected inner value? Correctly.
-    final inner_value = 84646234643264;
-    final inner_value2 = 846;
-    final inner_bool = true;
-
-    U32Value u32Value = (api.newU32Value(inner_value2) as U32Value);
-    U64Value u64Value = (api.newU64Value(inner_value) as U64Value);
-    I64Value i64Value = (api.newI64Value(inner_value) as I64Value);
-    I32Value i32Value = (api.newI32Value(inner_value2) as I32Value);
-
-    StringValue stringValue =
-        (api.newStringValue(inner_value.toString()) as StringValue);
-    BoolValue boolValue = (api.newBoolValue(inner_bool) as BoolValue);
-
     expect(u32Value.value, inner_value2);
     expect(i64Value.value, inner_value);
     expect(u64Value.value, inner_value);
@@ -28,8 +28,14 @@ void main() {
     expect(boolValue.value, inner_bool);
   });
 
-  // test('Passing Down/Lowering Enums', () {
-  //   Function eq = const ListEquality().equals;
-  //   expect(api.helloWorld(), "hello world");
-  // });
+  test('Passing Down/Lowering Enums', () {
+    // Can we pass the value down to rust correctly?
+    expect(api.takeValue(u32Value), inner_value2.toString());
+    expect(api.takeValue(i64Value), inner_value.toString());
+    expect(api.takeValue(u64Value), inner_value.toString());
+    expect(api.takeValue(i32Value), inner_value2.toString());
+
+    expect(api.takeValue(stringValue), inner_value.toString());
+    expect(api.takeValue(boolValue), inner_bool.toString());
+  });
 }

--- a/fixtures/large_enum/test/large_enum_test.dart
+++ b/fixtures/large_enum/test/large_enum_test.dart
@@ -3,4 +3,33 @@ import '../large_enum.dart';
 
 void main() {
   final api = Api.load();
+
+  test('Creating/Lifting Enums', () {
+    // Do we get the expected inner value? Correctly.
+    final inner_value = 84646234643264;
+    final inner_value2 = 846;
+    final inner_bool = true;
+
+    U32Value u32Value = (api.newU32Value(inner_value2) as U32Value);
+    U64Value u64Value = (api.newU64Value(inner_value) as U64Value);
+    I64Value i64Value = (api.newI64Value(inner_value) as I64Value);
+    I32Value i32Value = (api.newI32Value(inner_value2) as I32Value);
+
+    StringValue stringValue =
+        (api.newStringValue(inner_value.toString()) as StringValue);
+    BoolValue boolValue = (api.newBoolValue(inner_bool) as BoolValue);
+
+    expect(u32Value.value, inner_value2);
+    expect(i64Value.value, inner_value);
+    expect(u64Value.value, inner_value);
+    expect(i32Value.value, inner_value2);
+
+    expect(stringValue.value, inner_value.toString());
+    expect(boolValue.value, inner_bool);
+  });
+
+  // test('Passing Down/Lowering Enums', () {
+  //   Function eq = const ListEquality().equals;
+  //   expect(api.helloWorld(), "hello world");
+  // });
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -264,8 +264,6 @@ impl BindingsGenerator {
                 }
             }
 
-            $(primitives::generate_wrapper_lifters())
-
             String liftString(Api api, Uint8List input) {        
                 // we have a i32 length at the front
                 return utf8.decoder.convert(input);
@@ -299,6 +297,8 @@ impl BindingsGenerator {
                 }
                 return lifter(api, buf);
             }
+
+            $(primitives::generate_wrapper_lifters())
 
             Uint8List lowerOptional<T>(Api api, T? inp, Uint8List Function(Api, T) lowerer) {
                 if (inp == null) {

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -269,11 +269,15 @@ impl BindingsGenerator {
                 return utf8.decoder.convert(input);
             }
 
+            $(primitives::generate_primitives_lifters())
+           
             Uint8List lowerString(Api api, String input) {
                 // FIXME: this is too many memcopies!
                 return Utf8Encoder().convert(input);
 
             }
+
+            $(primitives::generate_primitives_lowerers())
 
             RustBuffer toRustBuffer(Api api, Uint8List data) {
                 final length = data.length;

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -264,7 +264,9 @@ impl BindingsGenerator {
                 }
             }
 
-            String liftString(Api api, Uint8List input) {
+            $(primitives::generate_wrapper_lifters())
+
+            String liftString(Api api, Uint8List input) {        
                 // we have a i32 length at the front
                 return utf8.decoder.convert(input);
             }
@@ -274,7 +276,6 @@ impl BindingsGenerator {
             Uint8List lowerString(Api api, String input) {
                 // FIXME: this is too many memcopies!
                 return Utf8Encoder().convert(input);
-
             }
 
             $(primitives::generate_primitives_lowerers())

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -322,6 +322,8 @@ impl BindingsGenerator {
                 return res;
             }
 
+            $(primitives::generate_wrapper_lowerers())
+
             class ForeignBytes extends Struct {
                 @Int32()
                 external int len;

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -95,7 +95,9 @@ fn generate_variant_factory(cls_name: &String, variant: &Variant) -> dart::Token
     quote! {
         factory $(class_name(variant.name()))$cls_name.lift(Api api, RustBuffer buffer) {
             Uint8List input = buffer.toIntList();
-            
+            // Keeping these two lines for debuging
+            print($(format!("'{}'",variant.name())));
+            print(input);
             int offset = 4; // Start at 4, because the first 32bits are the enum index
             List<dynamic> results = [];
 
@@ -112,7 +114,7 @@ fn generate_variant_lowerer(_cls_name: &String, index: usize, variant: &Variant)
         let lowerer = match field.as_type() {
             Type::Int8 | Type::UInt8 | Type::Int16 | Type::UInt16 | 
             Type::Int32 | Type::UInt32 | Type::Int64 | Type::UInt64  => quote!(createUint8ListFromInt(this.$(field.name()))),
-            Type::Boolean => quote!(createUint8ListFromInt(this.$(field.name()) ? 1 : 0)),
+            Type::Boolean => quote!(Uint8List.fromList([this.$(field.name()) ? 1 : 0])),
             Type::String => quote!(lowerString(api,this.$(field.name()))),
             _ => todo!("Add variant field lifter for type: {:?}", field.as_type())
         };

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -26,7 +26,7 @@ pub fn generate_enum(obj: &Enum) -> dart::Tokens {
                 }
     
                 static Uint8List lower(Api api, $cls_name input) {
-                    return createUint8ListFromInt(input.index);
+                    return createUint8ListFromInt(input.index + 1); // So enums aren't zero indexed?
                 }
             }
         }
@@ -118,7 +118,7 @@ fn generate_variant_lowerer(_cls_name: &String, index: usize, variant: &Variant)
         };
 
         quote! {
-            throw UnimplementedError("Create a list for all the different types, strings, bools, other enums, etc");
+            //throw UnimplementedError("Create a list for all the different types, strings, bools, other enums, etc");
             final $(field.name()) = $(lowerer);  
             $offset_var += $(field.name()).length;
         }
@@ -128,7 +128,7 @@ fn generate_variant_lowerer(_cls_name: &String, index: usize, variant: &Variant)
         Uint8List lower(Api api) {
             print($(format!("'{}'", variant.name())));
             // Turn all the fields to their int lists reprsentations
-            final index = createUint8ListFromInt($index);
+            final index = createUint8ListFromInt($(index + 1));
             int offset = 0;
             offset += index.length;
             $(for (index, field) in variant.fields().iter().enumerate() => $(generate_variant_field_lowerer(field, index, &quote!(offset))))

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -58,8 +58,9 @@ fn generate_variant_factory(cls_name: &String, variant: &Variant) -> dart::Token
              Type::Int16 | Type::UInt16 => quote!($results_list.insert($index, liftInt16OrUint16($uint8_list_var, $offset_var)); $offset_var += 2; ),
              Type::Int32 | Type::UInt32 => quote!($results_list.insert($index, liftInt32OrUint32($uint8_list_var, $offset_var)); $offset_var += 4; ),
              Type::Int64 | Type::UInt64 => quote!($results_list.insert($index, liftInt64OrUint64($uint8_list_var, $offset_var)); $offset_var += 8; ),
-             Type::Float32 => quote!($results_list.insert($index, liftFloat32($uint8_list_var, $offset_var); $offset_var += 4); ),
-             Type::Float64 => quote!($results_list.insert($index, liftFloat64($uint8_list_var, $offset_var); $offset_var += 8); ),
+             Type::Float32 => quote!($results_list.insert($index, liftFloat32($uint8_list_var, $offset_var)); $offset_var += 4; ),
+             Type::Float64 => quote!($results_list.insert($index, liftFloat64($uint8_list_var, $offset_var)); $offset_var += 1;  ) ,
+             Type::Boolean => quote!($results_list.insert($index, liftBoolean($uint8_list_var, $offset_var)); $offset_var += 1;  ),
              Type::String => quote!(final v = liftVaraibleLength($uint8_list_var, (buf) => liftString(api, buf), $offset_var);  $results_list.insert($index, v.data); $offset_var += v.offset;),
              _ => todo!("offset/size of Type::{:?}", field.as_type())
          }

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -115,7 +115,7 @@ fn generate_variant_lowerer(_cls_name: &String, index: usize, variant: &Variant)
             Type::Int8 | Type::UInt8 | Type::Int16 | Type::UInt16 | 
             Type::Int32 | Type::UInt32 | Type::Int64 | Type::UInt64  => quote!(createUint8ListFromInt(this.$(field.name()))),
             Type::Boolean => quote!(Uint8List.fromList([this.$(field.name()) ? 1 : 0])),
-            Type::String => quote!(lowerString(api,this.$(field.name()))),
+            Type::String => quote!(lowerVaraibleLength(api,this.$(field.name()), lowerString) ),
             _ => todo!("Add variant field lifter for type: {:?}", field.as_type())
         };
 

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -18,15 +18,35 @@ pub fn generate_enum(obj: &Enum) -> dart::Tokens {
         }
     } else {
         quote! {
-            abstract class $cls_name {}
+            abstract class $cls_name {
+                $cls_name();
+
+                factory Value.lift(Api api, RustBuffer buffer) {
+                    final index = buffer.toIntList().buffer.asByteData().getInt32(0);
+                    // Pass lifting onto the appropriate variant. based on index...variants are not 0 index
+                    $(for (index, variant) in obj.variants().iter().enumerate() =>
+                        if (index == $(index+1)) {
+                            return $(variant.name())$cls_name.lift(api, buffer);
+                        }
+                    )
+                    // If no return happens
+                    throw UniffiInternalError(6, "Unable to determine enum variant");
+                    // return $(class_name(obj.variants()[6].name()))Value(6);
+                    // //return $cls_name(7);
+                  }
+            }
 
             $(for variant in obj.variants()
                 => class $(class_name(variant.name()))$cls_name extends $cls_name {
                         $(for field in variant.fields() => final $(generate_type(&field.as_type())) $(var_name(field.name()));  )
 
-                        $(class_name(variant.name()))$cls_name(
-                            $(for field in variant.fields() => this.$(var_name(field.name())),  )
-                        );
+                        $(class_name(variant.name()))$cls_name($(for field in variant.fields() => this.$(var_name(field.name())),  ));
+
+                        factory $(class_name(variant.name()))$cls_name.lift(Api api, RustBuffer buffer) {
+                            // TODO: Impliment factory builders for each variant
+                            
+                            throw UniffiInternalError(6, "Not implimented");
+                        }
                     }
             )
         }

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -114,6 +114,8 @@ fn generate_variant_lowerer(_cls_name: &String, index: usize, variant: &Variant)
         let lowerer = match field.as_type() {
             Type::Int8 | Type::UInt8 | Type::Int16 | Type::UInt16 | 
             Type::Int32 | Type::UInt32 | Type::Int64 | Type::UInt64  => quote!(createUint8ListFromInt(this.$(field.name()))),
+            Type::Float32 => quote!(lowerFloat32(this.$(field.name()))),
+            Type::Float64  => quote!(lowerFloat64(this.$(field.name()))),
             Type::Boolean => quote!(Uint8List.fromList([this.$(field.name()) ? 1 : 0])),
             Type::String => quote!(lowerVaraibleLength(api,this.$(field.name()), lowerString) ),
             _ => todo!("Add variant field lifter for type: {:?}", field.as_type())

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -96,7 +96,7 @@ fn generate_variant_lowerer(_cls_name: &String, index: usize, variant: &Variant)
     fn generate_variant_field_lowerer(field: &Field, _index: usize, offset_var: &dart::Tokens) -> dart::Tokens {
         // TODO: Create a list for all the different types, strings, bools, other enums, etc...
         quote! {
-            throw UnimplimetedError;
+            throw UnimplementedError("Create a list for all the different types, strings, bools, other enums, etc");
             final $(field.name()) = createUint8ListFromInt(this.$(field.name()));  
             $offset_var += $(field.name()).length;
         }

--- a/src/gen/primitives.rs
+++ b/src/gen/primitives.rs
@@ -124,6 +124,34 @@ pub fn generate_primitives_lowerers() -> dart::Tokens {
             return uint8List;
         }
 
+        Uint8List lowerUint8(int value) {
+            final buf = Uint8List(1);
+            final byteData = ByteData.sublistView(buf);
+            byteData.setUint8(0, value);
+            return Uint8List.fromList(buf.toList());
+        }
+
+        Uint8List lowerInt8(int value) {
+            final buf = Uint8List(1);
+            final byteData = ByteData.sublistView(buf);
+            byteData.setInt8(0, value);
+            return Uint8List.fromList(buf.toList());
+        }
+
+        Uint8List lowerUint16(int value) {
+            final buf = Uint8List(2);
+            final byteData = ByteData.sublistView(buf);
+            byteData.setUint16(0, value);
+            return Uint8List.fromList(buf.toList());
+        }
+
+        Uint8List lowerInt16(int value) {
+            final buf = Uint8List(2);
+            final byteData = ByteData.sublistView(buf);
+            byteData.setInt16(0, value);
+            return Uint8List.fromList(buf.toList());
+        }
+
         Uint8List lowerFloat32(double value) {
             final buf = Uint8List(4);
             final byteData = ByteData.sublistView(buf);

--- a/src/gen/primitives.rs
+++ b/src/gen/primitives.rs
@@ -139,6 +139,19 @@ pub fn generate_primitives_lowerers() -> dart::Tokens {
     }
 }
 
+pub fn generate_wrapper_lowerers() -> dart::Tokens {
+    quote! {
+        Uint8List lowerVaraibleLength<T>(Api api, T input, Uint8List Function(Api, T) lowerer) {
+            final lowered = lowerer(api, input);
+            final length = createUint8ListFromInt(lowered.length);
+            Uint8List res = Uint8List(lowered.length + length.length);
+            res.setAll(0, length);
+            res.setAll(length.length, lowered);
+            return res;
+        }
+    }
+}
+
 macro_rules! impl_code_type_for_primitive {
     ($T:ty, $class_name:literal) => {
         paste! {

--- a/src/gen/primitives.rs
+++ b/src/gen/primitives.rs
@@ -97,7 +97,45 @@ pub fn generate_wrapper_lifters() -> dart::Tokens {
 
 pub fn generate_primitives_lowerers() -> dart::Tokens {
     quote! {
-        // TODO: Impliment lowerers for primitives
+        // TODO: Impliment lowerers for primitives        
+        Uint8List createUint8ListFromInt(int value) {
+            int length = value.bitLength ~/ 8 + 1;
+        
+            // Ensure the length is either 4 or 8
+            if (length != 4 && length != 8) {
+            length = (value < 0x100000000) ? 4 : 8;
+            }
+        
+            Uint8List uint8List = Uint8List(length);
+        
+            for (int i = length - 1; i >= 0; i--) {
+            uint8List[i] = value & 0xFF;
+            value >>= 8;
+            }
+        
+            return uint8List;
+        }
+
+        Uint8List createFixedSizedUint8ListFromFloat(double value) {
+            int length = 4; // Default to 32-bit (single-precision) float
+          
+            if (value.isFinite) {
+              if (value != value.truncateToDouble()) {
+                length = 8; // 64-bit (double-precision) float
+              }
+            }
+          
+            Uint8List uint8List = Uint8List(length);
+          
+            ByteData byteData = ByteData.sublistView(uint8List);
+            if (length == 4) {
+              byteData.setFloat32(0, value, Endian.little);
+            } else {
+              byteData.setFloat64(0, value, Endian.little);
+            }
+          
+            return uint8List;
+          }
     }
 }
 

--- a/src/gen/primitives.rs
+++ b/src/gen/primitives.rs
@@ -63,7 +63,15 @@ pub fn generate_primitives_lifters() -> dart::Tokens {
         }  
 
         double? liftFloat32(Uint8List buf, [int offset = 1]) {
-            return buf.isEmpty ? null : buf.buffer.asByteData().getFloat32(offset);
+            if (!buf.isEmpty) {
+                double res = buf.buffer.asByteData().getFloat32(offset);
+                res = double.parse(res.toStringAsFixed(6)); // Could adjust this later...
+                return res;
+            } else {
+                return null;
+            }
+           
+           // return buf.isEmpty ? null : buf.buffer.asByteData().getFloat32(offset);
         }
         
         double? liftFloat64(Uint8List buf, [int offset = 1]) {
@@ -116,26 +124,19 @@ pub fn generate_primitives_lowerers() -> dart::Tokens {
             return uint8List;
         }
 
-        Uint8List createFixedSizedUint8ListFromFloat(double value) {
-            int length = 4; // Default to 32-bit (single-precision) float
-          
-            if (value.isFinite) {
-              if (value != value.truncateToDouble()) {
-                length = 8; // 64-bit (double-precision) float
-              }
-            }
-          
-            Uint8List uint8List = Uint8List(length);
-          
-            ByteData byteData = ByteData.sublistView(uint8List);
-            if (length == 4) {
-              byteData.setFloat32(0, value, Endian.little);
-            } else {
-              byteData.setFloat64(0, value, Endian.little);
-            }
-          
-            return uint8List;
-          }
+        Uint8List lowerFloat32(double value) {
+            final buf = Uint8List(4);
+            final byteData = ByteData.sublistView(buf);
+            byteData.setFloat32(0, value, Endian.little);
+            return Uint8List.fromList(buf.reversed.toList());
+        }
+
+        Uint8List lowerFloat64(double value) {
+            final buf = Uint8List(8);
+            final byteData = ByteData.sublistView(buf);
+            byteData.setFloat64(0, value, Endian.little);
+            return Uint8List.fromList(buf.reversed.toList());
+        }
     }
 }
 

--- a/src/gen/primitives.rs
+++ b/src/gen/primitives.rs
@@ -1,6 +1,7 @@
 use paste::paste;
 use uniffi_bindgen::backend::{CodeType, Literal};
 use uniffi_bindgen::interface::{Radix, Type};
+use genco::prelude::*;
 
 fn render_literal(literal: &Literal) -> String {
     fn typed_number(type_: &Type, num_str: String) -> String {
@@ -40,6 +41,41 @@ fn render_literal(literal: &Literal) -> String {
         Literal::Float(string, type_) => typed_number(type_, string.clone()),
 
         _ => unreachable!("Literal"),
+    }
+}
+
+pub fn generate_primitives_lifters() -> dart::Tokens {
+    quote!{
+        //TODO!: Add booleans!
+        int? liftInt8OrUint8(Uint8List buf, [int offset = 1]) {
+            return buf.isEmpty ? null : buf.buffer.asByteData().getInt8(offset);
+        }
+
+        int? liftInt16OrUint16(Uint8List buf, [int offset = 1]) {
+            return buf.isEmpty ? null : buf.buffer.asByteData().getInt16(offset);
+        }
+
+        int? liftInt32OrUint32(Uint8List buf, [int offset = 1]) {
+            return buf.isEmpty ? null : buf.buffer.asByteData().getInt32(offset);
+        }
+
+        int? liftInt64OrUint64(Uint8List buf, [int offset = 1]) {
+            return buf.isEmpty ? null : buf.buffer.asByteData().getInt64(offset);
+        }  
+
+        double? liftFloat32(Uint8List buf, [int offset = 1]) {
+            return buf.isEmpty ? null : buf.buffer.asByteData().getFloat32(offset);
+        }
+        
+        double? liftFloat64(Uint8List buf, [int offset = 1]) {
+            return buf.isEmpty ? null : buf.buffer.asByteData().getFloat64(offset);
+        }
+    }
+}
+
+pub fn generate_primitives_lowerers() -> dart::Tokens {
+    quote! {
+        // TODO: Impliment lowerers for primitives
     }
 }
 

--- a/src/gen/primitives.rs
+++ b/src/gen/primitives.rs
@@ -73,6 +73,25 @@ pub fn generate_primitives_lifters() -> dart::Tokens {
     }
 }
 
+pub fn generate_wrapper_lifters() -> dart::Tokens {
+    quote! {
+        class DataOffset<T> {
+            final T? data;
+            final int offset;
+            DataOffset(this.data, this.offset);
+        }
+        
+        // Todo!: Make this guy handle varaible strings
+        DataOffset<T> liftVaraibleLength<T>(
+            Uint8List buf, T? Function(Uint8List) lifter,
+            [int offset = 1]) {
+            final length = buf.buffer.asByteData().getInt32(offset); // the length in Uint8
+            final liftedData = lifter(buf.sublist(offset));
+            return DataOffset(liftedData, length);
+        }
+    }
+}
+
 pub fn generate_primitives_lowerers() -> dart::Tokens {
     quote! {
         // TODO: Impliment lowerers for primitives

--- a/src/gen/primitives.rs
+++ b/src/gen/primitives.rs
@@ -46,7 +46,6 @@ fn render_literal(literal: &Literal) -> String {
 
 pub fn generate_primitives_lifters() -> dart::Tokens {
     quote!{
-        //TODO!: Add booleans!
         int? liftInt8OrUint8(Uint8List buf, [int offset = 1]) {
             return buf.isEmpty ? null : buf.buffer.asByteData().getInt8(offset);
         }
@@ -70,6 +69,10 @@ pub fn generate_primitives_lifters() -> dart::Tokens {
         double? liftFloat64(Uint8List buf, [int offset = 1]) {
             return buf.isEmpty ? null : buf.buffer.asByteData().getFloat64(offset);
         }
+
+        bool? liftBoolean(Uint8List buf, [int offset = 1]) {
+            return buf.isEmpty ? null : (buf.sublist(offset)[0] == 1 ? true : false);
+        }
     }
 }
 
@@ -86,7 +89,7 @@ pub fn generate_wrapper_lifters() -> dart::Tokens {
             Uint8List buf, T? Function(Uint8List) lifter,
             [int offset = 1]) {
             final length = buf.buffer.asByteData().getInt32(offset); // the length in Uint8
-            final liftedData = lifter(buf.sublist(offset));
+            final liftedData = lifter(buf.sublist(offset + 4));
             return DataOffset(liftedData, length);
         }
     }

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -106,7 +106,7 @@ pub fn convert_from_rust_buffer(ty: &Type, inner: dart::Tokens) -> dart::Tokens 
 pub fn convert_to_rust_buffer(ty: &Type, inner: dart::Tokens) -> dart::Tokens {
     match ty {
         Type::Object { .. } => inner,
-        Type::String | Type::Optional { .. } => quote!(toRustBuffer(api, $inner)),
+        Type::String | Type::Optional { .. } | Type::Enum { .. } => quote!(toRustBuffer(api, $inner)),
         _ => inner,
     }
 }
@@ -161,10 +161,8 @@ pub fn type_lower_fn(ty: &Type, inner: dart::Tokens) -> dart::Tokens {
         | Type::Boolean => quote!((($inner) ? 1 : 0)),
         Type::String => quote!(lowerString(api, $inner)),
         Type::Object { name, .. } => quote!($name.lower(api, $inner)),
-        Type::Optional { inner_type } => {
-            // TODO!: May still need to fix this. lowerOptional assumes offset 5 which may not be true for all types excpet strings
-            quote!(lowerOptional(api, $inner, (api, v) => $(type_lower_fn(inner_type, quote!(v)))))
-        }
+        Type::Enum { name, .. } => {quote!($name.lower(api, $inner))},
+        Type::Optional { inner_type } => quote!(lowerOptional(api, $inner, (api, v) => $(type_lower_fn(inner_type, quote!(v))))),
         _ => todo!("lower Type::{:?}", ty),
     }
 }

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -126,21 +126,21 @@ pub fn type_lift_fn(ty: &Type, inner: dart::Tokens) -> dart::Tokens {
         Type::Boolean => quote!(($inner) > 0),
         Type::String => quote!(liftString(api, $inner)),
         Type::Object { name, .. } => quote!($name.lift(api, $inner)),
+        Type::Enum { name, .. } => quote!($name.lift(api, $inner)),
         Type::Optional { inner_type } => type_lift_optional_inner_type(inner_type, inner),
         _ => todo!("lift Type::{:?}", ty),
     }
 }
 
-// The usefull part of the data contained inside optional may have a
-// different offset depending on the type.
+
 fn type_lift_optional_inner_type(inner_type: &Box<Type>, inner: dart::Tokens) -> dart::Tokens {
     match **inner_type {
-        Type::Int8 | Type::UInt8 => quote!(liftOptional(api, $inner, (api, v) => v.isEmpty ? null : v.buffer.asByteData().getInt8(1))),
-        Type::Int16 | Type::UInt16 => quote!(liftOptional(api, $inner, (api, v) => v.isEmpty ? null : v.buffer.asByteData().getInt16(1))),
-        Type::Int32 | Type::UInt32 => quote!(liftOptional(api, $inner, (api, v) => v.isEmpty ? null : v.buffer.asByteData().getInt32(1))),
-        Type::Int64 | Type::UInt64 => quote!(liftOptional(api, $inner, (api, v) => v.isEmpty ? null : v.buffer.asByteData().getInt64(1))),
-        Type::Float32 => quote!(liftOptional(api, $inner, (api, v) => v.isEmpty ? null : v.buffer.asByteData().getFloat32(1))),
-        Type::Float64 => quote!(liftOptional(api, $inner, (api, v) => v.isEmpty ? null : v.buffer.asByteData().getFloat64(1))),
+        Type::Int8 | Type::UInt8 => quote!(liftOptional(api, $inner, (api, v) => liftInt8OrUint8(v))),
+        Type::Int16 | Type::UInt16 => quote!(liftOptional(api, $inner, (api, v) => liftInt16OrUint16(v))),
+        Type::Int32 | Type::UInt32 => quote!(liftOptional(api, $inner, (api, v) => liftInt32OrUint32(v))),
+        Type::Int64 | Type::UInt64 => quote!(liftOptional(api, $inner, (api, v) => liftInt64OrUint64(v))),
+        Type::Float32 => quote!(liftOptional(api, $inner, (api, v) => liftFloat32(v))),
+        Type::Float64 => quote!(liftOptional(api, $inner, (api, v) => liftFloat64(v))),
         Type::String => quote!(liftOptional(api, $inner, (api, v) => $(type_lift_fn(inner_type, quote!(v.sublist(5))))) ),
         _ => todo!("lift Option inner type: Type::{:?}", inner_type)
     }

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -157,8 +157,8 @@ pub fn type_lower_fn(ty: &Type, inner: dart::Tokens) -> dart::Tokens {
         | Type::Int64
         | Type::UInt64
         | Type::Float32
-        | Type::Float64
-        | Type::Boolean => inner,
+        | Type::Float64 => inner,
+        | Type::Boolean => quote!((($inner) ? 1 : 0)),
         Type::String => quote!(lowerString(api, $inner)),
         Type::Object { name, .. } => quote!($name.lower(api, $inner)),
         Type::Optional { inner_type } => {


### PR DESCRIPTION
## Implemented Flat and Complex enums
At this point, all tests with primitives and strings inside complex enums pass for both lifting and lowering, the same is true for flat enums. Since Dart doesn't support complex associative types, this implementation works around this by generating abstract classes, factories, and static functions declared in the root abstract class, since it's not always possible to know which variant you're getting. There could be a better way to do this but for now... It should do...

This branch also contains a few fixes...

### Next steps
- [ ] Add support for collections like vectors, maps, etc.... and enums inside enums
- [ ] Add more tests
- [ ] Implement futures and async support