### PR TITLE
Add support for duration primitive type in code generation

### DIFF
--- a/fixtures/duration_type_test/Cargo.toml
+++ b/fixtures/duration_type_test/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "duration_type_test"
+version = "0.1.0"
+edition = "2021"
+publish = false
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+
+[lib]
+name = "duration_type_test"
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+uniffi = { workspace = true }
+
+[build-dependencies]
+uniffi-dart = { path = "../../", features = ["build"] }
+
+[dev-dependencies]
+uniffi-dart = { path = "../../", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }
+anyhow = "1"

--- a/fixtures/duration_type_test/build.rs
+++ b/fixtures/duration_type_test/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi_dart::generate_scaffolding("./src/api.udl".into()).unwrap();
+}

--- a/fixtures/duration_type_test/src/api.udl
+++ b/fixtures/duration_type_test/src/api.udl
@@ -1,0 +1,1 @@
+namespace duration_type_test { };

--- a/fixtures/duration_type_test/src/lib.rs
+++ b/fixtures/duration_type_test/src/lib.rs
@@ -7,13 +7,13 @@ pub fn add_duration(seconds: i64, nanos: i32) -> Duration {
 }
 
 #[uniffi::export]
-pub fn get_seconds(duration: Duration) -> i64 {
-    duration.as_secs() as i64
+pub fn get_seconds(duration: Duration) -> u64 {
+    duration.as_secs() as u64
 }
 
 #[uniffi::export]
-pub fn get_nanos(duration: Duration) -> i32 {
-    duration.as_nanos() as i32 % 1_000_000_000
+pub fn get_nanos(duration: Duration) -> u32 {
+    duration.as_nanos() as u32 % 1_000_000_000
 }
 
 // #[cfg(test)]
@@ -26,4 +26,5 @@ pub fn get_nanos(duration: Duration) -> i32 {
 //         assert_eq!(get_nanos(add_duration(1, 1)), 1);
 //     }
 // }
+
 uniffi::include_scaffolding!("api");

--- a/fixtures/duration_type_test/src/lib.rs
+++ b/fixtures/duration_type_test/src/lib.rs
@@ -1,0 +1,33 @@
+use uniffi;
+
+#[uniffi::export]
+pub fn add_duration_seconds(left: u64, right: u64) -> u64 {
+    (left as i64 + right as i64) as u64
+}
+
+#[uniffi::export]
+pub fn add_duration_milliseconds(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[uniffi::export]
+pub fn add_duration_microseconds(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[uniffi::export]
+pub fn get_back_duration_seconds(value: u64) -> u64 {
+    value
+}
+
+#[uniffi::export]
+pub fn get_back_duration_milliseconds(value: u64) -> u64 {
+    value
+}
+
+#[uniffi::export]
+pub fn get_back_duration_microseconds(value: u64) -> u64 {
+    value
+}
+
+uniffi::include_scaffolding!("api");

--- a/fixtures/duration_type_test/src/lib.rs
+++ b/fixtures/duration_type_test/src/lib.rs
@@ -2,29 +2,18 @@ use core::time::Duration;
 use uniffi;
 
 #[uniffi::export]
-pub fn add_duration(seconds: i64, nanos: i32) -> Duration {
-    Duration::new(seconds as u64, nanos as u32)
+pub fn make_duration(seconds: u64, nanos: u32) -> Duration {
+    Duration::new(seconds, nanos)
 }
 
 #[uniffi::export]
 pub fn get_seconds(duration: Duration) -> u64 {
-    duration.as_secs() as u64
+    duration.as_secs()
 }
 
 #[uniffi::export]
 pub fn get_nanos(duration: Duration) -> u32 {
-    duration.as_nanos() as u32 % 1_000_000_000
+    duration.subsec_nanos()
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-
-//     #[test]
-//     fn test_add_duration() {
-//         assert_eq!(get_seconds(add_duration(1, 1)), 1);
-//         assert_eq!(get_nanos(add_duration(1, 1)), 1);
-//     }
-// }
 
 uniffi::include_scaffolding!("api");

--- a/fixtures/duration_type_test/src/lib.rs
+++ b/fixtures/duration_type_test/src/lib.rs
@@ -1,33 +1,29 @@
+use core::time::Duration;
 use uniffi;
 
 #[uniffi::export]
-pub fn add_duration_seconds(left: u64, right: u64) -> u64 {
-    (left as i64 + right as i64) as u64
+pub fn add_duration(seconds: i64, nanos: i32) -> Duration {
+    Duration::new(seconds as u64, nanos as u32)
 }
 
 #[uniffi::export]
-pub fn add_duration_milliseconds(left: u64, right: u64) -> u64 {
-    left + right
+pub fn get_seconds(duration: Duration) -> i64 {
+    duration.as_secs() as i64
 }
 
 #[uniffi::export]
-pub fn add_duration_microseconds(left: u64, right: u64) -> u64 {
-    left + right
+pub fn get_nanos(duration: Duration) -> i32 {
+    duration.as_nanos() as i32 % 1_000_000_000
 }
 
-#[uniffi::export]
-pub fn get_back_duration_seconds(value: u64) -> u64 {
-    value
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
 
-#[uniffi::export]
-pub fn get_back_duration_milliseconds(value: u64) -> u64 {
-    value
-}
-
-#[uniffi::export]
-pub fn get_back_duration_microseconds(value: u64) -> u64 {
-    value
-}
-
+//     #[test]
+//     fn test_add_duration() {
+//         assert_eq!(get_seconds(add_duration(1, 1)), 1);
+//         assert_eq!(get_nanos(add_duration(1, 1)), 1);
+//     }
+// }
 uniffi::include_scaffolding!("api");

--- a/fixtures/duration_type_test/test/duration_type_test.dart
+++ b/fixtures/duration_type_test/test/duration_type_test.dart
@@ -3,7 +3,33 @@ import '../duration_type_test.dart';
 
 void main() {
   final api = Api.load();
-  final duration = api.addDuration(1, 1);
-  expect(api.getSeconds(duration), equals(1));
-  expect(api.getNanos(duration), equals(1));
+  test('rust return value seconds check', () {
+    final duration = api.makeDuration(5, 0);
+
+    expect(duration.inSeconds, 5);
+    expect(api.getSeconds(duration), 5);
+    expect(api.getNanos(duration), 0);
+  });
+
+  test('seconds data check from dart', () {
+    final duration = Duration(seconds: 10);
+    expect(api.getSeconds(duration), 10);
+    expect(api.getNanos(duration), 0);
+  });
+
+  test('check nanos/micros', () {
+    final duration = api.makeDuration(0, 3000);
+    expect(duration.inSeconds, 0);
+    expect(duration.inMicroseconds, 3);
+    expect(api.getSeconds(duration), 0);
+    expect(api.getNanos(duration), 3000);
+  });
+
+  test('check large values', () {
+    final duration = api.makeDuration(123456789, 3000000);
+    expect(duration.inSeconds, 123456789);
+    expect(duration.inMicroseconds, 123456789003000);
+    expect(api.getSeconds(duration), 123456789);
+    expect(api.getNanos(duration), 3000000);
+  });
 }

--- a/fixtures/duration_type_test/test/duration_type_test.dart
+++ b/fixtures/duration_type_test/test/duration_type_test.dart
@@ -1,0 +1,24 @@
+import 'package:test/test.dart';
+import '../duration_type_test.dart';
+
+void main() {
+  final api = Api.load();
+  test('addDurationSeconds', () {
+    expect(api.addDurationSeconds(2, 2), 4);
+  });
+  test('addDurationMilliseconds', () {
+    expect(api.addDurationMilliseconds(2000, 2000), 4000);
+  });
+  test('addDurationMicroseconds', () {
+    expect(api.addDurationMicroseconds(2000000, 2000000), 4000000);
+  });
+  test('getBackDurationSeconds', () {
+    expect(api.getBackDurationSeconds(4), 4);
+  });
+  test('getBackDurationMilliseconds', () {
+    expect(api.getBackDurationMilliseconds(4000), 4000);
+  });
+  test('getBackDurationMicroseconds', () {
+    expect(api.getBackDurationMicroseconds(4000000), 4000000);
+  });
+}

--- a/fixtures/duration_type_test/test/duration_type_test.dart
+++ b/fixtures/duration_type_test/test/duration_type_test.dart
@@ -3,22 +3,7 @@ import '../duration_type_test.dart';
 
 void main() {
   final api = Api.load();
-  test('addDurationSeconds', () {
-    expect(api.addDurationSeconds(2, 2), 4);
-  });
-  test('addDurationMilliseconds', () {
-    expect(api.addDurationMilliseconds(2000, 2000), 4000);
-  });
-  test('addDurationMicroseconds', () {
-    expect(api.addDurationMicroseconds(2000000, 2000000), 4000000);
-  });
-  test('getBackDurationSeconds', () {
-    expect(api.getBackDurationSeconds(4), 4);
-  });
-  test('getBackDurationMilliseconds', () {
-    expect(api.getBackDurationMilliseconds(4000), 4000);
-  });
-  test('getBackDurationMicroseconds', () {
-    expect(api.getBackDurationMicroseconds(4000000), 4000000);
-  });
+  final duration = api.addDuration(1, 1);
+  expect(api.getSeconds(duration), equals(1));
+  expect(api.getNanos(duration), equals(1));
 }

--- a/fixtures/duration_type_test/tests/mod.rs
+++ b/fixtures/duration_type_test/tests/mod.rs
@@ -1,0 +1,6 @@
+use anyhow::Result;
+
+#[test]
+fn duration_type_test() -> Result<()> {
+    uniffi_dart::testing::run_test("duration_type_test", "src/api.udl", None)
+}

--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -200,13 +200,13 @@ impl DartCodeOracle {
             | Type::UInt32
             | Type::UInt64
             | Type::Float32
-            | Type::Float64 => inner,
+            | Type::Float64
+            | Type::Duration => inner,
             Type::Boolean
             | Type::String
             | Type::Object { .. }
             | Type::Enum { .. }
             | Type::Record { .. }
-            | Type::Duration { .. }
             | Type::Optional { .. } => quote!($(ty.as_codetype().lift())(api, $inner)),
             _ => todo!("lift Type::{:?}", ty),
         }
@@ -236,14 +236,14 @@ impl DartCodeOracle {
             | Type::Int64
             | Type::UInt64
             | Type::Float32
-            | Type::Float64 => inner,
+            | Type::Float64
+            | Type::Duration => inner,
             Type::Boolean
             | Type::String
             | Type::Object { .. }
             | Type::Enum { .. }
             | Type::Optional { .. }
             | Type::Record { .. }
-            | Type::Duration { .. }
             | Type::Sequence { .. } => quote!($(ty.as_codetype().lower())(api, $inner)),
             //      => quote!(lowerSequence(api, value, lowerUint8, 1)), // TODO: Write try lower primitives, then check what a sequence actually looks like and replicate it
             _ => todo!("lower Type::{:?}", ty),
@@ -338,6 +338,7 @@ impl<T: AsType> AsCodeType for T {
             Type::Float64 => Box::new(primitives::Float64CodeType),
             Type::Boolean => Box::new(primitives::BooleanCodeType),
             Type::String => Box::new(primitives::StringCodeType),
+            Type::Duration => Box::new(primitives::DurationCodeType),
             Type::Object { name, .. } => Box::new(objects::ObjectCodeType::new(name)),
             Type::Optional { inner_type } => Box::new(compounds::OptionalCodeType::new(
                 self.as_type(),

--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -200,9 +200,9 @@ impl DartCodeOracle {
             | Type::UInt32
             | Type::UInt64
             | Type::Float32
-            | Type::Float64
-            | Type::Duration => inner,
+            | Type::Float64 => inner,
             Type::Boolean
+            | Type::Duration
             | Type::String
             | Type::Object { .. }
             | Type::Enum { .. }
@@ -236,9 +236,9 @@ impl DartCodeOracle {
             | Type::Int64
             | Type::UInt64
             | Type::Float32
-            | Type::Float64
-            | Type::Duration => inner,
+            | Type::Float64 => inner,
             Type::Boolean
+            | Type::Duration
             | Type::String
             | Type::Object { .. }
             | Type::Enum { .. }

--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -206,6 +206,7 @@ impl DartCodeOracle {
             | Type::Object { .. }
             | Type::Enum { .. }
             | Type::Record { .. }
+            | Type::Duration { .. }
             | Type::Optional { .. } => quote!($(ty.as_codetype().lift())(api, $inner)),
             _ => todo!("lift Type::{:?}", ty),
         }
@@ -242,6 +243,7 @@ impl DartCodeOracle {
             | Type::Enum { .. }
             | Type::Optional { .. }
             | Type::Record { .. }
+            | Type::Duration { .. }
             | Type::Sequence { .. } => quote!($(ty.as_codetype().lower())(api, $inner)),
             //      => quote!(lowerSequence(api, value, lowerUint8, 1)), // TODO: Write try lower primitives, then check what a sequence actually looks like and replicate it
             _ => todo!("lower Type::{:?}", ty),

--- a/src/gen/primitives.rs
+++ b/src/gen/primitives.rs
@@ -96,10 +96,10 @@ pub fn generate_wrapper_lifters() -> dart::Tokens {
             return DataOffset(liftedData, length);
         }
 
-        DataOffset<T> liftDuration(Uint8List buf, [int offset = 0]) {
+        DataOffset<Duration> liftDuration(Uint8List buf, [int offset = 0]) {
             final seconds = buf.buffer.asByteData().getInt64(offset);
-            final nanoseconds = buf.buffer.asByteData().getInt64(offset + 8);
-            final duration = Duration(seconds: seconds, nanoseconds: nanoseconds);
+            final microseconds = buf.buffer.asByteData().getInt64(offset + 8);
+            final duration = Duration(seconds: seconds, microseconds: microseconds);
             return DataOffset(duration, offset);
         }
 
@@ -152,10 +152,10 @@ pub fn generate_wrapper_lowerers() -> dart::Tokens {
             return res;
         }
 
-        Uint8List lowerDuration(Api api, Duration input) {
+        Uint8List lowerDuration(Duration input) {
             Uint8List uint8List = Uint8List(16);
-            uint8List.buffer.asByteData().setInt64(0, input.seconds);
-            uint8List.buffer.asByteData().setInt64(8, input.nanoseconds);
+            uint8List.buffer.asByteData().setInt64(0, input.inSeconds);
+            uint8List.buffer.asByteData().setInt64(8, input.inMicroseconds % 1000000);
             return uint8List;
         }
 

--- a/src/gen/primitives/duration.rs
+++ b/src/gen/primitives/duration.rs
@@ -13,22 +13,23 @@ impl Renderable for DurationCodeType {
         quote! {
             class FfiConverterDuration {
                 static Duration lift(Api api, RustBuffer buf) {
-                    final seconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(0);
-                    final nanoseconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(8);
+                    final bufList = buf.asUint8List();
+                    final seconds = bufList.buffer.asByteData(bufList.offsetInBytes).getInt64(0);
+                    final nanoseconds = bufList.buffer.asByteData(bufList.offsetInBytes).getInt64(8);
                     return Duration(seconds: seconds, microseconds: nanoseconds ~/ 1000);
                 }
 
                 static RustBuffer lower(Api api, Duration value) {
                     final buf = Uint8List(16);
-                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(0, value.seconds);
-                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.microseconds * 1000);
+                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(0, value.inSeconds);
+                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.inMicroseconds * 1000);
                     return toRustBuffer(api, buf);
                 }
 
                 static LiftRetVal<Duration> read(Api api, Uint8List buf) {
                     final seconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(0);
-                    final microseconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(8);
-                    return LiftRetVal(Duration(seconds: seconds, microseconds: nanoseconds ~/ 1000), 16, 16);
+                    final nanoseconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(8);
+                    return LiftRetVal(Duration(seconds: seconds, microseconds: nanoseconds ~/ 1000), 16);
                 }
 
                 static int allocationSize([Duration value = const Duration()]) {
@@ -36,8 +37,8 @@ impl Renderable for DurationCodeType {
                 }
 
                 static int write(Api api, Duration value, Uint8List buf) {
-                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(0, value.seconds);
-                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.microseconds * 1000);
+                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(0, value.inSeconds);
+                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.inMicroseconds * 1000);
                     return 16;
                 }
             }

--- a/src/gen/primitives/duration.rs
+++ b/src/gen/primitives/duration.rs
@@ -1,0 +1,46 @@
+use crate::gen::{
+    quote,
+    render::{Renderable, TypeHelperRenderer},
+};
+
+use super::paste;
+use genco::lang::dart;
+
+impl_code_type_for_primitive!(DurationCodeType, "duration", "Duration");
+
+impl Renderable for DurationCodeType {
+    fn render_type_helper(&self, _type_helper: &dyn TypeHelperRenderer) -> dart::Tokens {
+        quote! {
+            class FfiConverterDuration {
+                static Duration lift(Api api, RustBuffer buf) {
+                    let seconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(0);
+                    let microseconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(8);
+                    return Duration { seconds, microseconds };
+                }
+
+                static RustBuffer lower(Api api, Duration value) {
+                    let mut buf = Uint8List(16);
+                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(0, value.seconds);
+                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.microseconds % 1000000000);
+                    return toRustBuffer(api, buf);
+                }
+
+                static LiftRetVal<Duration> read(Api api, Uint8List buf) {
+                    let seconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(0);
+                    let microseconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(8);
+                    return LiftRetVal(Duration { seconds, microseconds }, 16);
+                }
+
+                static int allocationSize([Duration value = Duration { seconds: 0, microseconds: 0 }]) {
+                    return 16;
+                }
+
+                static int write(Api api, Duration value, Uint8List buf) {
+                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(0, value.seconds);
+                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.microseconds);
+                    return 16;
+                }
+            }
+        }
+    }
+}

--- a/src/gen/primitives/duration.rs
+++ b/src/gen/primitives/duration.rs
@@ -13,33 +13,34 @@ impl Renderable for DurationCodeType {
         quote! {
             class FfiConverterDuration {
                 static Duration lift(Api api, RustBuffer buf) {
-                    final bufList = buf.asUint8List();
-                    final seconds = bufList.buffer.asByteData(bufList.offsetInBytes).getInt64(0);
-                    final nanoseconds = bufList.buffer.asByteData(bufList.offsetInBytes).getInt64(8);
-                    return Duration(seconds: seconds, microseconds: nanoseconds ~/ 1000);
+                    return FfiConverterDuration.read(api, buf.asUint8List()).value;
                 }
 
                 static RustBuffer lower(Api api, Duration value) {
-                    final buf = Uint8List(16);
-                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(0, value.inSeconds);
-                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.inMicroseconds * 1000);
+                    final buf = Uint8List(12);
+                    FfiConverterDuration.write(api, value, buf);
                     return toRustBuffer(api, buf);
                 }
 
                 static LiftRetVal<Duration> read(Api api, Uint8List buf) {
-                    final seconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(0);
-                    final nanoseconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(8);
-                    return LiftRetVal(Duration(seconds: seconds, microseconds: nanoseconds ~/ 1000), 16);
+                    final bytes = buf.buffer.asByteData(buf.offsetInBytes, 12);
+                    final seconds = bytes.getUint64(0);
+                    final micros = (bytes.getUint32(8) ~/ 1000);
+                    return LiftRetVal(Duration(seconds: seconds, microseconds: micros), 12);
                 }
 
                 static int allocationSize([Duration value = const Duration()]) {
-                    return 16;
+                    return 12;
                 }
 
                 static int write(Api api, Duration value, Uint8List buf) {
-                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(0, value.inSeconds);
-                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.inMicroseconds * 1000);
-                    return 16;
+                    final bytes = buf.buffer.asByteData(buf.offsetInBytes, 12);
+                    bytes.setUint64(0, value.inSeconds);
+                    final ms = (value.inMicroseconds - (value.inSeconds * 1000000)) * 1000;
+                    if (ms > 0) {
+                        bytes.setUint32(8, ms.toInt());
+                    }
+                    return 12;
                 }
             }
         }

--- a/src/gen/primitives/duration.rs
+++ b/src/gen/primitives/duration.rs
@@ -13,31 +13,31 @@ impl Renderable for DurationCodeType {
         quote! {
             class FfiConverterDuration {
                 static Duration lift(Api api, RustBuffer buf) {
-                    let seconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(0);
-                    let microseconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(8);
-                    return Duration { seconds, microseconds };
+                    final seconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(0);
+                    final nanoseconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(8);
+                    return Duration(seconds: seconds, microseconds: nanoseconds ~/ 1000);
                 }
 
                 static RustBuffer lower(Api api, Duration value) {
-                    let mut buf = Uint8List(16);
+                    final buf = Uint8List(16);
                     buf.buffer.asByteData(buf.offsetInBytes).setInt64(0, value.seconds);
-                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.microseconds % 1000000000);
+                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.microseconds * 1000);
                     return toRustBuffer(api, buf);
                 }
 
                 static LiftRetVal<Duration> read(Api api, Uint8List buf) {
-                    let seconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(0);
-                    let microseconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(8);
-                    return LiftRetVal(Duration { seconds, microseconds }, 16);
+                    final seconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(0);
+                    final microseconds = buf.buffer.asByteData(buf.offsetInBytes).getInt64(8);
+                    return LiftRetVal(Duration(seconds: seconds, microseconds: nanoseconds ~/ 1000), 16, 16);
                 }
 
-                static int allocationSize([Duration value = Duration { seconds: 0, microseconds: 0 }]) {
+                static int allocationSize([Duration value = const Duration()]) {
                     return 16;
                 }
 
                 static int write(Api api, Duration value, Uint8List buf) {
                     buf.buffer.asByteData(buf.offsetInBytes).setInt64(0, value.seconds);
-                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.microseconds);
+                    buf.buffer.asByteData(buf.offsetInBytes).setInt64(8, value.microseconds * 1000);
                     return 16;
                 }
             }

--- a/src/gen/render/mod.rs
+++ b/src/gen/render/mod.rs
@@ -41,7 +41,8 @@ pub trait Renderable {
             | Type::Int64
             | Type::UInt16
             | Type::Int32
-            | Type::UInt64 => quote!(int),
+            | Type::UInt64
+            | Type::Duration => quote!(int),
             Type::Float32 | Type::Float64 => quote!(double),
             Type::String => quote!(String),
             Type::Object { name, .. } => quote!($name),
@@ -109,6 +110,7 @@ impl<T: AsType> AsRenderable for T {
             Type::Float64 => Box::new(primitives::Float64CodeType),
             Type::Boolean => Box::new(primitives::BooleanCodeType),
             Type::String => Box::new(primitives::StringCodeType),
+            Type::Duration => Box::new(primitives::DurationCodeType),
             Type::Object { name, .. } => Box::new(objects::ObjectCodeType::new(name)),
             Type::Optional { inner_type, .. } => Box::new(compounds::OptionalCodeType::new(
                 self.as_type(),
@@ -122,10 +124,10 @@ impl<T: AsType> AsRenderable for T {
             Type::Record { name, module_path } => {
                 Box::new(records::RecordCodeType::new(name, module_path))
             }
+
             _ => todo!("Renderable for Type::{:?}", self.as_type()), // Type::Bytes => Box::new(primitives::BytesCodeType),
 
                                                                      // Type::Timestamp => Box::new(miscellany::TimestampCodeType),
-                                                                     // Type::Duration => Box::new(miscellany::DurationCodeType),
 
                                                                      // Type::Object { name, .. } => Box::new(object::ObjectCodeType::new(name)),
                                                                      // Type::Record(id) => Box::new(record::RecordCodeType::new(id)),

--- a/src/gen/render/mod.rs
+++ b/src/gen/render/mod.rs
@@ -41,12 +41,12 @@ pub trait Renderable {
             | Type::Int64
             | Type::UInt16
             | Type::Int32
-            | Type::UInt64
-            | Type::Duration => quote!(int),
+            | Type::UInt64 => quote!(int),
             Type::Float32 | Type::Float64 => quote!(double),
             Type::String => quote!(String),
             Type::Object { name, .. } => quote!($name),
             Type::Boolean => quote!(bool),
+            Type::Duration => quote!(Duration),
             Type::Optional { inner_type } => quote!($(&self.render_type(inner_type, type_helper))?),
             Type::Sequence { inner_type } => {
                 quote!(List<$(&self.render_type(inner_type, type_helper))>)

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -365,6 +365,7 @@ pub fn generate_type(ty: &Type) -> dart::Tokens {
         | Type::Int64
         | Type::UInt16
         | Type::Int32
+        | Type::Duration
         | Type::UInt64 => quote!(int),
         Type::Float32 | Type::Float64 => quote!(double),
         Type::String => quote!(String),


### PR DESCRIPTION
- [x] Implement `render_literal` function for Duration literals.
- [x] Add `impl_code_type_for_primitive!` and `impl_renderable_for_primitive!` instances for `DurationCodeType`.
- [x] Add `liftDuration` and `lowerDuration` functions to `generate_wrapper_lifters` and `generate_wrapper_lowerers` respectively.
- [x] Update `generate_wrapper_lifters` and `generate_wrapper_lowerers` to handle Duration type.
- [x] Update tests.