### PR TITLE
Fix RustBuffer.len typo

### DIFF
--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -471,7 +471,7 @@ impl DartCodeOracle {
                             outReturn.ref = toRustBuffer(Uint8List.fromList([0]));
                         } else {
                             final lowered = $lowered.lower(result);
-                            final buffer = Uint8List(1 + lowered.length);
+                            final buffer = Uint8List(1 + lowered.len);
                             buffer[0] = 1;
                             buffer.setAll(1, lowered.asUint8List());
                             outReturn.ref = toRustBuffer(buffer);


### PR DESCRIPTION
`length` doesn't exist on RustBuffer, resulting in an error when handling callbacks for Optional return values (as seen here https://github.com/payjoin/rust-payjoin/pull/1061#issuecomment-3321592959).