### PR TITLE
Fix Dart byte converter to respect view bounds

### DIFF
--- a/src/gen/primitives/macros.rs
+++ b/src/gen/primitives/macros.rs
@@ -59,8 +59,7 @@ macro_rules! impl_renderable_for_primitive {
 
                         static int write($type_signature value, Uint8List buf) {
                             buf.buffer.asByteData(buf.offsetInBytes).setInt32(0, value.length);
-                            int offset = buf.offsetInBytes + 4;
-                            buf.setRange(offset, offset + value.length, value);
+                            buf.setRange(4, 4 + value.length, value);
                             return 4 + value.length;
                         }
                     }


### PR DESCRIPTION
The generated `FfiConverterUint8List.write` was using the underlying buffer offset when calling `setRange`, so nested views tried to write outside their slice and threw a RangeError. 

I updated the template to copy bytes relative to the current view instead.
