### PR TITLE
Fix UnexpectedEnumCase in decoding

### DIFF
--- a/fixtures/dart_async/src/lib.rs
+++ b/fixtures/dart_async/src/lib.rs
@@ -176,9 +176,37 @@ pub struct MyRecord {
     pub b: u32,
 }
 
+#[derive(uniffi::Enum)]
+pub enum AsyncItemState {
+    Ready { timestamp_ms: u64 },
+    Pending { reason: String },
+}
+
+#[derive(uniffi::Record)]
+pub struct AsyncItem {
+    pub id: u64,
+    pub state: AsyncItemState,
+}
+
 #[uniffi::export]
 pub async fn new_my_record(a: String, b: u32) -> MyRecord {
     MyRecord { a, b }
+}
+
+#[uniffi::export]
+pub fn list_async_items() -> Vec<AsyncItem> {
+    vec![
+        AsyncItem {
+            id: 1,
+            state: AsyncItemState::Ready { timestamp_ms: 1111 },
+        },
+        AsyncItem {
+            id: 2,
+            state: AsyncItemState::Pending {
+                reason: "syncing".to_string(),
+            },
+        },
+    ]
 }
 
 /// Non-blocking timer future used to test callback cancellation.

--- a/fixtures/dart_async/test/futures_test.dart
+++ b/fixtures/dart_async/test/futures_test.dart
@@ -273,4 +273,17 @@ void main() {
       expect(true, true); // Expected to throw
     }
   });
+
+  test('decode sequence of records containing payload enums', () {
+    final items = listAsyncItems();
+    expect(items.length, 2);
+
+    final firstState = items[0].state as ReadyAsyncItemState;
+    expect(items[0].id, 1);
+    expect(firstState.timestampMs, 1111);
+
+    final secondState = items[1].state as PendingAsyncItemState;
+    expect(items[1].id, 2);
+    expect(secondState.reason, 'syncing');
+  });
 }

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -363,7 +363,8 @@ pub fn generate_enum(obj: &Enum, type_helper: &dyn TypeHelperRenderer) -> dart::
                     switch(index) {
                         $(for (index, variant) in obj.variants().iter().enumerate() =>
                         case $(index + 1):
-                            return $(format!("{}{}", DartCodeOracle::class_name(variant.name()), dart_cls_name)).read(subview);
+                            final lifted = $(format!("{}{}", DartCodeOracle::class_name(variant.name()), dart_cls_name)).read(subview);
+                            return LiftRetVal<$dart_cls_name>(lifted.value, lifted.bytesRead - subview.offsetInBytes + 4);
                         )
                         default:  throw UniffiInternalError(UniffiInternalError.unexpectedEnumCase, "Unable to determine enum variant");
                     }
@@ -378,7 +379,7 @@ pub fn generate_enum(obj: &Enum, type_helper: &dyn TypeHelperRenderer) -> dart::
                 }
 
                 static int write( $dart_cls_name value, Uint8List buf) {
-                    return value.write(buf);
+                    return value.write(buf) - buf.offsetInBytes;
                 }
             }
 


### PR DESCRIPTION
Looking to address #107  UnexpectedEnumCase / decode errors for non-flat enums in Dart bindings when enums are nested in records/sequences.  

I think root cause was offset accounting where generated non-flat enum converters were returning absolute offsets from read+write, while parent converters consume relative byte counts.

Changes made in PR to normalize non-flat enum read+write bytes to relative offsets and adding regression coverage, but feel free to let me know if I'm on the wrong track or missing something.

## More detail

The enum in bdk-dart that caused the issue was:

```
enum ChainPosition {
  Confirmed { confirmation_block_time: ..., transitively: ... },
  Unconfirmed { timestamp: ... },
}
```

bdk-dart has other non-flat enums but i think this showed up as an issue specifically because wallet.transactions() path decodes a sequence of records contaning ChainPosition
