### PR TITLE
Add release issue template and versioning docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,36 @@
+---
+name: Release
+about: Checklist for releasing a new version of uniffi-dart
+title: "Release vX.Y.Z+vA.B.C"
+labels: release
+assignees: ''
+---
+
+## Release checklist
+
+Replace `X.Y.Z` with the uniffi-dart version and `A.B.C` with the
+targeted uniffi-rs version throughout.
+
+### Version bump
+
+- [ ] Determine version: bump **minor** for breaking changes, **patch**
+      otherwise
+- [ ] Update `version` in `Cargo.toml` (e.g. `0.X.Y+v0.A.B`)
+
+### Documentation
+
+- [ ] Update installation instructions in `README.md`
+- [ ] If the upstream uniffi-rs version changed, add a row to the
+      versioning table in `README.md`
+- [ ] Update `CHANGELOG.md` — prefix breaking changes with
+      `**BREAKING**:` and critical fixes with `**IMPORTANT**:`
+
+### Review & merge
+
+- [ ] Open a PR with the above changes
+- [ ] Get approval and merge to `main`
+
+### Tag & release
+
+- [ ] Create a git tag on `main`: `vX.Y.Z+vA.B.C`
+- [ ] Create a GitHub Release from the tag with the changelog entry

--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ Our comprehensive fixture suite has identified 5 critical blocking features:
 4. **Trait method support** - Advanced trait functionality
 5. **BigInt support** - Large integer boundary handling
 
+## Versioning
+
+uniffi-dart is versioned independently from uniffi-rs. We follow the
+[SemVer rules from the Cargo Book](https://doc.rust-lang.org/cargo/reference/semver.html)
+where versions are compatible when their left-most non-zero component
+matches. A breaking change is any modification to the generated Dart
+bindings that requires consumers to update their code.
+
+Because the project is still young, the major version is 0 and most
+updates bump the minor version.
+
+To keep binding generators in sync, uniffi-dart targets a specific
+uniffi-rs release. If you use multiple external binding generators, pick
+versions that target the same uniffi-rs version.
+
+Tags follow the format `vX.Y.Z+vA.B.C`, where `X.Y.Z` is the
+uniffi-dart version and `A.B.C` is the targeted uniffi-rs version.
+
+| uniffi-dart version | uniffi-rs version |
+|---------------------|-------------------|
+| v0.1.0              | v0.30.0           |
+
 ## License & Credits
 
 The code is released under MIT License. See the LICENSE file in the repository root for details.


### PR DESCRIPTION
Add a GitHub issue template with a release checklist covering version bumps, documentation updates, PR review, and tagging. Add a versioning section to the README explaining the independent versioning scheme from uniffi-rs and the vX.Y.Z+vA.B.C tag format.