### PR TITLE
Prepare v0.1.0+v0.30.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to uniffi-dart will be documented in this file.
+
+## v0.1.0+v0.30.0
+
+Initial release of uniffi-dart targeting uniffi-rs v0.30.0.
+
+### Dart binding generation
+
+- All primitive types with bounds checking
+- Strings, bytes, optionals, sequences, and maps
+- Records with default values and named constructors
+- Enums (flat and complex) with variant support
+- Objects with constructors, methods, and disposable pattern
+- Error types and exception handling
+- Custom types
+- Durations and timestamps
+
+### Async support
+
+- Async/Future support for functions, methods, and constructors
+- Callback interfaces (UDL and proc-macro)
+- Trait interfaces
+- Stream support via extension macros
+
+### Code generation
+
+- Named parameters for generated functions and objects
+- Multiple namespace support
+- Dart Native Assets with `@Native` annotations
+- Configurable library loading strategy
+- Formatted generated Dart code
+
+### Testing
+
+- Comprehensive test suite
+- CI with downstream testing (rust-payjoin and bdk-dart)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-dart"
-version = "0.1.0"
+version = "0.1.0+v0.30.0"
 edition = "2021"
 license = "Apache-2 or MIT"
 homepage = "https://github.com/acterglobal/uniffi-dart"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ Dart frontend for UniFFI bindings
 
 ![License: MIT](https://img.shields.io/github/license/acterglobal/uniffi-dart?style=flat-square) ![Status: experimental](https://img.shields.io/badge/status-experimental-red?style=flat-square)
 
+## Installation
+
+Add uniffi-dart as a dependency in your `Cargo.toml`:
+
+```toml
+[dependencies]
+uniffi-dart = "0.1.0+v0.30.0"
+```
+
 ## Testing & Fixtures
 
 uniffi-dart includes a **comprehensive test suite** with 30 fixtures covering all major UniFFI functionality:

--- a/uniffi_dart_macro/Cargo.toml
+++ b/uniffi_dart_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_dart_macro"
-version = "0.1.0"
+version = "0.1.0+v0.30.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Bump crate versions to 0.1.0+v0.30.0, add installation instructions to README, and create the initial CHANGELOG.