### PR TITLE
fix: generate FfiConverter for Sequence/Optional of records in callback interfaces

### DIFF
--- a/fixtures/callbacks/src/api.udl
+++ b/fixtures/callbacks/src/api.udl
@@ -1,5 +1,17 @@
 namespace callbacks { };
 
+// Record types used only in callback interface compound positions
+// (sequence<Record> and Record?) to test FfiConverter generation.
+dictionary Item {
+  string name;
+  u64 value;
+};
+
+dictionary Tag {
+  u32 id;
+  string label;
+};
+
 [Error]
 enum SimpleError {
   "BadArgument",
@@ -27,6 +39,9 @@ callback interface ForeignGetters {
   sequence<i32> get_list(sequence<i32> v, boolean arg2);
   [Throws=SimpleError]
   void get_nothing(string v);
+  // Test compound types wrapping records in callback signatures
+  sequence<Item> get_items(sequence<Item> v);
+  Tag? get_tag(Tag? v);
 };
 
 /// These objects are implemented in Rust, and call out to `ForeignGetters`
@@ -45,6 +60,9 @@ interface RustGetters {
   string? get_string_optional_callback(ForeignGetters? callback, string v, boolean arg2);
   [Throws=SimpleError]
   void get_nothing(ForeignGetters callback, string v);
+  // Test compound types wrapping records
+  sequence<Item> get_items(ForeignGetters callback, sequence<Item> v);
+  Tag? get_tag(ForeignGetters callback, Tag? v);
 };
 
 /// These objects are implemented by the foreign language and passed

--- a/fixtures/callbacks/src/lib.rs
+++ b/fixtures/callbacks/src/lib.rs
@@ -1,11 +1,23 @@
 use uniffi;
 
+pub struct Item {
+    pub name: String,
+    pub value: u64,
+}
+
+pub struct Tag {
+    pub id: u32,
+    pub label: String,
+}
+
 trait ForeignGetters {
     fn get_bool(&self, v: bool, argument_two: bool) -> Result<bool, SimpleError>;
     fn get_string(&self, v: String, arg2: bool) -> Result<String, SimpleError>;
     fn get_option(&self, v: Option<String>, arg2: bool) -> Result<Option<String>, ComplexError>;
     fn get_list(&self, v: Vec<i32>, arg2: bool) -> Result<Vec<i32>, SimpleError>;
     fn get_nothing(&self, v: String) -> Result<(), SimpleError>;
+    fn get_items(&self, v: Vec<Item>) -> Vec<Item>;
+    fn get_tag(&self, v: Option<Tag>) -> Option<Tag>;
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -87,6 +99,14 @@ impl RustGetters {
 
     fn get_nothing(&self, callback: Box<dyn ForeignGetters>, v: String) -> Result<(), SimpleError> {
         callback.get_nothing(v)
+    }
+
+    fn get_items(&self, callback: Box<dyn ForeignGetters>, v: Vec<Item>) -> Vec<Item> {
+        callback.get_items(v)
+    }
+
+    fn get_tag(&self, callback: Box<dyn ForeignGetters>, v: Option<Tag>) -> Option<Tag> {
+        callback.get_tag(v)
     }
 }
 

--- a/fixtures/callbacks/test/callbacks_test.dart
+++ b/fixtures/callbacks/test/callbacks_test.dart
@@ -41,6 +41,12 @@ class DartGetters extends ForeignGetters {
       throw SimpleException.unexpectedError;
     }
   }
+
+  @override
+  List<Item> getItems(List<Item> v) => v;
+
+  @override
+  Tag? getTag(Tag? v) => v;
 }
 
 class StoredDartStringifier extends StoredForeignStringifier {
@@ -116,6 +122,31 @@ void main() {
   test('getNothing should not throw with normal argument', () {
     // Should not throw
     rustGetters.getNothing(callback, "1234567890123");
+  });
+
+  test('roundtrip getItems (sequence<Record>) through callback', () {
+    final items = [
+      Item(name: 'foo', value: 100),
+      Item(name: 'bar', value: 200),
+    ];
+    final result = rustGetters.getItems(callback, items);
+    expect(result.length, equals(2));
+    expect(result[0].name, equals('foo'));
+    expect(result[0].value, equals(100));
+    expect(result[1].name, equals('bar'));
+    expect(result[1].value, equals(200));
+  });
+
+  test('roundtrip getTag (Optional<Record>) through callback', () {
+    final tag = Tag(id: 42, label: 'test');
+    final result = rustGetters.getTag(callback, tag);
+    expect(result, isNotNull);
+    expect(result!.id, equals(42));
+    expect(result.label, equals('test'));
+
+    // Also test with null
+    final nullResult = rustGetters.getTag(callback, null);
+    expect(nullResult, isNull);
   });
 
   // test('getString throws SimpleException.BadArgument', () {

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -110,12 +110,25 @@ impl Renderer<(FunctionDefinition, dart::Tokens)> for TypeHelpersRenderer<'_> {
             )
         );
 
-        // Ensure callback interfaces are registered for helper generation
+        // Ensure callback interfaces and their method parameter/return types
+        // are registered for helper generation. We must do this before taking
+        // the snapshot in get_include_names(), so that compound types like
+        // Sequence<Record> or Optional<Record> that only appear in callback
+        // interface signatures get their FfiConverter classes generated.
         for callback in self.ci.callback_interface_definitions() {
             self.include_once_check(
                 &callback.as_type().as_codetype().canonical_name(),
                 &callback.as_type(),
             );
+            // Walk callback method signatures to register compound types
+            for method in callback.methods() {
+                for arg in method.arguments() {
+                    arg.as_renderable().render_type(&arg.as_type(), self);
+                }
+                if let Some(ret) = method.return_type() {
+                    ret.as_renderable().render_type(ret, self);
+                }
+            }
         }
 
         // Let's include the string converter


### PR DESCRIPTION
Fixes https://github.com/Uniffi-Dart/uniffi-dart/issues/116

## Problem

The code generator does not emit `FfiConverterSequence*` and `FfiConverterOptional*` classes for record types that only appear in callback interface method signatures, causing undefined class errors in generated Dart code.

## Root Cause

`get_include_names()` returns a snapshot of registered types. Callback interface method types are registered after the snapshot is taken, so their compound type converters are never generated.

## Fix

Pre-walk callback interface method signatures before the snapshot, so compound types like `Sequence<Record>` and `Optional<Record>` are registered in time.

## Test coverage

Extended the `callbacks` fixture with `sequence<Item>` and `Tag?` in callback interface signatures. Verified `FfiConverterSequenceItem` and `FfiConverterOptionalTag` are generated.