### PR TITLE
use Optional FfiConverter's lower() for inner types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     # Working fixtures - only include fixtures that actually work
     "fixtures/arithmetic",
     "fixtures/bytes_types",
+    "fixtures/callbacks",
     "fixtures/duration_type_test",
     "fixtures/type-limits",
     "fixtures/hello_world",

--- a/fixtures/callbacks/test/callbacks_test.dart
+++ b/fixtures/callbacks/test/callbacks_test.dart
@@ -24,7 +24,7 @@ class DartGetters extends ForeignGetters {
       throw ReallyBadArgumentComplexException(20); // Example of a complex error
     }
     if (v == 'UnexpectedError') {
-      throw UnexpectedExceptionWithReasonComplexException("something failed");
+      throw UnexpectedErrorWithReasonComplexException("something failed");
     }
     return arg2 ? v?.toUpperCase() : v;
   }
@@ -65,13 +65,17 @@ void main() {
 
   final callback = DartGetters();
   final rustGetters = RustGetters();
-  final rustStringifier = RustStringifier(StoredDartStringifier());
+  final rustStringifier = RustStringifier(callback: StoredDartStringifier());
 
   test('roundtrip getBool through callback', () {
     final flag = true;
     for (final v in [true, false]) {
       final expected = callback.getBool(v, flag);
-      final observed = rustGetters.getBool(callback, v, flag);
+      final observed = rustGetters.getBool(
+        callback: callback,
+        v: v,
+        argumentTwo: flag,
+      );
       expect(observed, equals(expected));
     }
   });
@@ -84,7 +88,11 @@ void main() {
       [0, 1],
     ]) {
       final expected = callback.getList(v, flag);
-      final observed = rustGetters.getList(callback, v, flag);
+      final observed = rustGetters.getList(
+        callback: callback,
+        v: v,
+        arg2: flag,
+      );
       expect(observed, equals(expected));
     }
   });
@@ -93,7 +101,11 @@ void main() {
     final flag = true;
     for (final v in ["Hello", "world"]) {
       final expected = callback.getString(v, flag);
-      final observed = rustGetters.getString(callback, v, flag);
+      final observed = rustGetters.getString(
+        callback: callback,
+        v: v,
+        arg2: flag,
+      );
       expect(observed, equals(expected));
     }
   });
@@ -102,26 +114,38 @@ void main() {
     final flag = true;
     for (final v in ["Some"]) {
       final expected = callback.getOption(v, flag);
-      final observed = rustGetters.getOption(callback, v, flag);
+      final observed = rustGetters.getOption(
+        callback: callback,
+        v: v,
+        arg2: flag,
+      );
       expect(observed, equals(expected));
     }
   });
 
   test('getStringOptionalCallback works', () {
     expect(
-      rustGetters.getStringOptionalCallback(callback, "1234567890123", false),
+      rustGetters.getStringOptionalCallback(
+        callback: callback,
+        v: "1234567890123",
+        arg2: false,
+      ),
       equals("1234567890123"),
     );
     // Passing null as the callback
     expect(
-      rustGetters.getStringOptionalCallback(null, "1234567890123", false),
+      rustGetters.getStringOptionalCallback(
+        callback: null,
+        v: "1234567890123",
+        arg2: false,
+      ),
       isNull,
     );
   });
 
   test('getNothing should not throw with normal argument', () {
     // Should not throw
-    rustGetters.getNothing(callback, "1234567890123");
+    rustGetters.getNothing(callback: callback, v: "1234567890123");
   });
 
   test('roundtrip getItems (sequence<Record>) through callback', () {
@@ -129,7 +153,7 @@ void main() {
       Item(name: 'foo', value: 100),
       Item(name: 'bar', value: 200),
     ];
-    final result = rustGetters.getItems(callback, items);
+    final result = rustGetters.getItems(callback: callback, v: items);
     expect(result.length, equals(2));
     expect(result[0].name, equals('foo'));
     expect(result[0].value, equals(100));
@@ -139,13 +163,13 @@ void main() {
 
   test('roundtrip getTag (Optional<Record>) through callback', () {
     final tag = Tag(id: 42, label: 'test');
-    final result = rustGetters.getTag(callback, tag);
+    final result = rustGetters.getTag(callback: callback, v: tag);
     expect(result, isNotNull);
     expect(result!.id, equals(42));
     expect(result.label, equals('test'));
 
     // Also test with null
-    final nullResult = rustGetters.getTag(callback, null);
+    final nullResult = rustGetters.getTag(callback: callback, v: null);
     expect(nullResult, isNull);
   });
 

--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -466,33 +466,19 @@ impl DartCodeOracle {
                     outReturn.value = result;
                 )
             }
-            Type::Optional { inner_type } => {
-                // For optional return values
-                if let Type::String = **inner_type {
-                    quote!(
-                        final result = obj.$method_name($(for arg in &args => $arg,));
-                        if (result == null) {
-                            outReturn.ref = toRustBuffer(Uint8List.fromList([0]));
-                        } else {
-                            final lowered = FfiConverterOptionalString.lower(result);
-                            outReturn.ref = toRustBuffer(lowered.asUint8List());
-                        }
-                    )
-                } else {
-                    let lowered = ret_type.as_codetype().ffi_converter_name();
-                    quote!(
-                        final result = obj.$method_name($(for arg in &args => $arg,));
-                        if (result == null) {
-                            outReturn.ref = toRustBuffer(Uint8List.fromList([0]));
-                        } else {
-                            final lowered = $lowered.lower(result);
-                            final buffer = Uint8List(1 + lowered.len);
-                            buffer[0] = 1;
-                            buffer.setAll(1, lowered.asUint8List());
-                            outReturn.ref = toRustBuffer(buffer);
-                        }
-                    )
-                }
+            Type::Optional { .. } => {
+                // For optional return values, use the Optional FfiConverter which already
+                // handles the discriminant byte encoding correctly.
+                let ffi_converter = ret_type.as_codetype().ffi_converter_name();
+                quote!(
+                    final result = obj.$method_name($(for arg in &args => $arg,));
+                    if (result == null) {
+                        outReturn.ref = toRustBuffer(Uint8List.fromList([0]));
+                    } else {
+                        final lowered = $ffi_converter.lower(result);
+                        outReturn.ref = toRustBuffer(lowered.asUint8List());
+                    }
+                )
             }
             Type::String => {
                 // For string return values


### PR DESCRIPTION
The old non-String case was manually prepending a discriminant byte on top of a RustBuffer that already contained one.
This caused uniffi conversion errors in generated bindings.