### PR TITLE
fix: type helpers for aliases, compounds & callback args

### DIFF
--- a/src/gen/code_type.rs
+++ b/src/gen/code_type.rs
@@ -1,6 +1,8 @@
 use std::fmt::Debug;
 use uniffi_bindgen::pipeline::general::nodes::Literal;
 
+use crate::gen::render::TypeHelperRenderer;
+
 /// A trait tor the implementation.
 pub trait CodeType: Debug {
     /// The language specific label used to reference this type. This will be used in
@@ -48,4 +50,6 @@ pub trait CodeType: Debug {
     fn read(&self) -> String {
         format!("{}.read", self.ffi_converter_name())
     }
+
+    fn add_additional_type_helpers(&self, helper: &dyn TypeHelperRenderer) {}
 }

--- a/src/gen/compounds.rs
+++ b/src/gen/compounds.rs
@@ -33,6 +33,10 @@ macro_rules! impl_code_type_for_compound {
                 fn canonical_name(&self) -> String {
                     format!($canonical_name_pattern, DartCodeOracle::find(self.inner()).canonical_name())
                 }
+
+                fn add_additional_type_helpers(&self, type_helper: &dyn TypeHelperRenderer) {
+                    type_helper.include_once_check(&self.inner().as_codetype().canonical_name(), self.inner());
+                }
             }
         }
     }

--- a/src/gen/custom.rs
+++ b/src/gen/custom.rs
@@ -26,6 +26,10 @@ impl CodeType for CustomCodeType {
     fn type_label(&self) -> String {
         DartCodeOracle::class_name(&self.name)
     }
+    
+    fn add_additional_type_helpers(&self, type_helper: &dyn TypeHelperRenderer) {
+        type_helper.include_once_check(&self.builtin.as_codetype().canonical_name(), &self.builtin);
+    }
 }
 
 impl AsType for CustomCodeType {

--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -325,6 +325,10 @@ impl DartCodeOracle {
                     let type_name = &DartCodeOracle::class_name(name);
                     quote!($type_name)
                 }
+                Type::CallbackInterface { name, .. } => {
+                    let type_name = &DartCodeOracle::class_name(name);
+                    quote!($type_name)
+                }
                 _ => quote!(dynamic),
             }
         } else {

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -35,6 +35,7 @@ impl<'a> TypeHelpersRenderer<'a> {
 impl TypeHelperRenderer for TypeHelpersRenderer<'_> {
     // Checks if the type imports for each type have already been added
     fn include_once_check(&self, name: &str, ty: &Type) -> bool {
+        ty.as_codetype().add_additional_type_helpers(self);
         let mut map = self.include_once_names.borrow_mut();
         let found = map.insert(name.to_string(), ty.clone()).is_some();
         drop(map);


### PR DESCRIPTION
This PR fixes three issues I encountered while trying to use this project to convert https://github.com/gorules/zen/tree/master/bindings/uniffi.
1. Missing type helper for custom type aliases: When the actual underlying type of a custom type alias was not explicitly declared in the code, the type helper for that underlying type was not generated.
Example: 
```rust
pub struct JsonBuffer(pub Vec<u8>);
uniffi::custom_newtype!(JsonBuffer, Vec<u8>);
```
```dart
// actual: not generated
class FfiConverterUint8List
```
2. Missing type helper for compound inner types: Type helpers were not generated for the inner types of compound types.
Example: 
```rust
#[derive(uniffi::Record)]
pub struct ZenEngineResponse {
    pub performance: String,
    pub result: JsonBuffer,
    pub trace: Option<HashMap<String, ZenEngineTrace>>,
}
```
```dart
// actual: not generated
class FfiConverterMapStringToZenEngineTrace
```
3. Incorrect type for CallbackInterface arguments: When a method's argument was a CallbackInterface, the actual type was not used; instead, dynamic was used.
Example: 
```rust
#[uniffi::constructor]
    pub fn new(
        loader: Option<Box<dyn ZenDecisionLoaderCallback>>,
        custom_node: Option<Box<dyn ZenCustomNodeCallback>>,
    ) -> Self { ...
```
```dart
// actual
ZenEngine({required dynamic? loader,required dynamic? customNode,})
// expected
ZenEngine({required ZenDecisionLoaderCallback? loader,required ZenCustomNodeCallback? customNode,})
```
The actual effect of the changes can be verified by following the steps below. After execution, you can check the files in the build/generated/dart folder.
```bash
git clone https://github.com/Sociosarbis/zen.git
cd zen/bindings/uniffi
make build
make generate-dart
```