### PR TITLE
Add WASM web target support to uniffi-dart bindings

### DIFF
--- a/fixtures/callbacks/test/callbacks_test.dart
+++ b/fixtures/callbacks/test/callbacks_test.dart
@@ -57,8 +57,8 @@ class StoredDartStringifier extends StoredForeignStringifier {
   String fromComplexType(List<double?>? values) => 'kotlin: $values';
 }
 
-void main() {
-  ensureInitialized();
+Future<void> main() async {
+  await ensureInitialized();
   // Initialize all VTables
   initForeignGettersVTable();
   initStoredForeignStringifierVTable();

--- a/fixtures/dart_async/test/futures_test.dart
+++ b/fixtures/dart_async/test/futures_test.dart
@@ -8,9 +8,8 @@ Future<Duration> measureTime(Future<void> Function() action) async {
   return end.difference(start);
 }
 
-void main() {
-  initialize();
-  ensureInitialized();
+Future<void> main() async {
+  await ensureInitialized();
 
   test('greet', () async {
     final result = greet(who: "Somebody");

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -33,6 +33,7 @@ mod records;
 mod render;
 pub mod stream;
 mod types;
+mod web;
 
 pub use code_type::CodeType;
 
@@ -103,10 +104,10 @@ impl Config {
         self.generate_web
     }
 
-    pub fn wasm_module_name(&self) -> String {
+    pub fn wasm_module_name(&self, namespace: &str) -> String {
         self.wasm_module_name
             .clone()
-            .unwrap_or_else(|| format!("__uniffi_{}", self.package_name()))
+            .unwrap_or_else(|| format!("__uniffi_{namespace}"))
     }
 
     pub fn web_unsupported_policy(&self) -> &str {
@@ -148,6 +149,10 @@ impl<'a> DartWrapper<'a> {
         quote! {
             export $(quoted(format!("{ns}_stub.dart")));
         }
+    }
+
+    fn generate_web(&self) -> Result<dart::Tokens> {
+        web::WebDartWrapper::new(self.ci, self.config).generate()
     }
 
     fn generate_native(&self) -> dart::Tokens {
@@ -671,9 +676,26 @@ impl BindingGenerator for DartBindingGenerator {
         settings: &uniffi_bindgen::GenerationSettings,
         components: &[uniffi_bindgen::Component<Self::Config>],
     ) -> Result<()> {
+        web::validate_unique_wasm_module_names(
+            components
+                .iter()
+                .filter(|component| component.config.generate_web())
+                .map(|component| {
+                    (
+                        component.ci.namespace().to_string(),
+                        component.config.wasm_module_name(component.ci.namespace()),
+                    )
+                }),
+        )?;
+
         for Component { ci, config, .. } in components {
             let ns = ci.namespace();
             let wrapper = DartWrapper::new(ci, config);
+            let web_tokens = if config.generate_web() {
+                wrapper.generate_web()?
+            } else {
+                wrapper.generate_web_placeholder()
+            };
 
             let src_dir = settings.out_dir.join("src");
             std::fs::create_dir_all(&src_dir)?;
@@ -695,7 +717,7 @@ impl BindingGenerator for DartBindingGenerator {
             )?;
             write_dart_file(
                 &src_dir.join(format!("{ns}_web.dart")),
-                wrapper.generate_web_placeholder(),
+                web_tokens,
                 settings.try_format_code,
             )?;
         }
@@ -896,6 +918,34 @@ mod tests {
         String::from_utf8(buf).expect("non-UTF8 output")
     }
 
+    fn normalize_whitespace(s: &str) -> String {
+        s.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    fn stub_export_statement(output: &str, stub_file: &str) -> String {
+        let export_start = output
+            .find(&format!("export \"{stub_file}\""))
+            .expect("stub export missing");
+        let export_end = output[export_start..]
+            .find(';')
+            .map(|offset| export_start + offset)
+            .expect("stub export terminator missing");
+
+        normalize_whitespace(&output[export_start..=export_end])
+    }
+
+    fn assert_stub_export_hides(output: &str, stub_file: &str, hidden_names: &[&str]) {
+        let statement = stub_export_statement(output, stub_file);
+        let hide_list = statement
+            .split(" hide ")
+            .nth(1)
+            .expect("stub export should contain a hide clause")
+            .trim_end_matches(';');
+        let actual: Vec<_> = hide_list.split(',').map(str::trim).collect();
+
+        assert_eq!(actual, hidden_names, "unexpected stub export hide list");
+    }
+
     #[test]
     fn entry_point_ffi_precedes_js_interop() {
         let ci = ComponentInterface::new("test_ns");
@@ -915,5 +965,175 @@ mod tests {
             "ffi must appear before js_interop for native-wins precedence, \
              but ffi at {ffi_pos}, js_interop at {js_pos}.\nGenerated:\n{output}"
         );
+    }
+
+    #[test]
+    fn web_output_includes_js_interop_runtime() {
+        let ci = ComponentInterface::from_webidl(
+            r#"
+            namespace test_ns {
+                string greet(string name);
+            };
+            "#,
+            "test_ns",
+        )
+        .expect("test UDL should parse");
+        let mut config = Config::from(&ci);
+        config.generate_web = true;
+        config.wasm_module_name = Some("__uniffi_test_ns".to_string());
+        let wrapper = DartWrapper::new(&ci, &config);
+        let output = render_tokens(wrapper.generate_web().expect("web generation"));
+
+        assert!(output.contains("import \"dart:js_interop\";"));
+        assert_stub_export_hides(
+            &output,
+            "test_ns_stub.dart",
+            &["ensureInitialized", "initialize", "greet"],
+        );
+        assert!(output.contains("__uniffi_test_ns.init"));
+        assert!(output.contains("__uniffi_test_ns.test_ns_greet"));
+        assert!(output.contains("Future<void> ensureInitialized({String? wasmPath})"));
+        assert!(output.contains("uniffi_error"));
+        assert!(output.contains("uniffi_internal"));
+        assert!(output.contains("uniffi_panic"));
+    }
+
+    #[test]
+    fn duplicate_wasm_module_names_are_rejected() {
+        let result = web::validate_unique_wasm_module_names([
+            ("first".to_string(), "__uniffi_shared".to_string()),
+            ("second".to_string(), "__uniffi_shared".to_string()),
+        ]);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn default_wasm_module_name_uses_namespace_not_package_name() {
+        let ci = ComponentInterface::from_webidl(
+            r#"
+            namespace component_ns {
+                string greet();
+            };
+            "#,
+            "component_ns",
+        )
+        .expect("test UDL should parse");
+        let mut config = Config::from(&ci);
+        config.package_name = Some("shared_package".to_string());
+
+        assert_eq!(
+            config.wasm_module_name(ci.namespace()),
+            "__uniffi_component_ns"
+        );
+    }
+
+    #[test]
+    fn distinct_wasm_module_names_are_accepted() {
+        let result = web::validate_unique_wasm_module_names([
+            ("first".to_string(), "__uniffi_first".to_string()),
+            ("second".to_string(), "__uniffi_second".to_string()),
+        ]);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn web_unsupported_policy_error_fails_generation() {
+        let ci = ComponentInterface::from_webidl(
+            include_str!("../../fixtures/simple-fns/src/api.udl"),
+            "simple_fns",
+        )
+        .expect("simple-fns UDL should parse");
+        let mut config = Config::from(&ci);
+        config.generate_web = true;
+        config.web_unsupported_policy = "error".to_string();
+        let wrapper = DartWrapper::new(&ci, &config);
+
+        assert!(wrapper.generate_web().is_err());
+    }
+
+    #[test]
+    fn web_unsupported_policy_error_rejects_object_only_components() {
+        let ci = ComponentInterface::from_webidl(
+            r#"
+            namespace test_ns {
+            };
+
+            interface Thing {
+                constructor();
+                void touch();
+            };
+            "#,
+            "test_ns",
+        )
+        .expect("test UDL should parse");
+        let mut config = Config::from(&ci);
+        config.generate_web = true;
+        config.web_unsupported_policy = "error".to_string();
+        let wrapper = DartWrapper::new(&ci, &config);
+
+        assert!(wrapper.generate_web().is_err());
+    }
+
+    #[test]
+    fn web_output_excludes_64_bit_integer_functions_until_lossless() {
+        let ci = ComponentInterface::from_webidl(
+            r#"
+            namespace test_ns {
+                i64 signed_big(i64 value);
+                u64 unsigned_big(u64 value);
+            };
+            "#,
+            "test_ns",
+        )
+        .expect("test UDL should parse");
+        let mut config = Config::from(&ci);
+        config.generate_web = true;
+        let wrapper = DartWrapper::new(&ci, &config);
+        let output = render_tokens(wrapper.generate_web().expect("web generation"));
+
+        assert_stub_export_hides(
+            &output,
+            "test_ns_stub.dart",
+            &["ensureInitialized", "initialize"],
+        );
+        assert!(!output.contains("__uniffi_test_ns.test_ns_signed_big"));
+        assert!(!output.contains("__uniffi_test_ns.test_ns_unsigned_big"));
+        assert!(!output.contains("JSBigInt"));
+    }
+
+    #[test]
+    fn web_output_selectively_hides_supported_simple_fns() {
+        let ci = ComponentInterface::from_webidl(
+            include_str!("../../fixtures/simple-fns/src/api.udl"),
+            "simple_fns",
+        )
+        .expect("simple-fns UDL should parse");
+        let mut config = Config::from(&ci);
+        config.generate_web = true;
+        let wrapper = DartWrapper::new(&ci, &config);
+        let output = render_tokens(wrapper.generate_web().expect("web generation"));
+
+        assert_stub_export_hides(
+            &output,
+            "simple_fns_stub.dart",
+            &[
+                "ensureInitialized",
+                "initialize",
+                "byteToU32",
+                "getInt",
+                "getString",
+                "stringIdentity",
+            ],
+        );
+        assert!(output.contains("getString"));
+        assert!(output.contains("getInt"));
+        assert!(output.contains("stringIdentity"));
+        assert!(output.contains("byteToU32"));
+        assert!(output.contains("__uniffi_simple_fns.simple_fns_get_string"));
+        assert!(output.contains("__uniffi_simple_fns.simple_fns_byte_to_u32"));
+        assert!(!output.contains("__uniffi_simple_fns.simple_fns_dummy"));
+        assert!(!output.contains("__uniffi_simple_fns.simple_fns_new_set"));
     }
 }

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -264,15 +264,19 @@ impl<'a> DartWrapper<'a> {
                 )
             }
 
-            void ensureInitialized() {
+            void _runApiChecks() {
                 _checkApiVersion();
                 _checkApiChecksums();
+            }
+
+            Future<void> ensureInitialized({String? wasmPath}) async {
+                _runApiChecks();
             }
 
             // Backwards-compatible entry point used by existing tests
             @Deprecated("Use ensureInitialized instead")
             void initialize() {
-                ensureInitialized();
+                _runApiChecks();
             }
         }
     }
@@ -321,12 +325,7 @@ impl<'a> DartWrapper<'a> {
 
             $stream_stubs
 
-            void ensureInitialized() {
-                throw UnsupportedError($(quoted(format!("{ns} is not supported on this platform"))));
-            }
-
-            @Deprecated("Use ensureInitialized instead")
-            void initialize() {
+            Future<void> ensureInitialized({String? wasmPath}) async {
                 throw UnsupportedError($(quoted(format!("{ns} is not supported on this platform"))));
             }
         }
@@ -968,6 +967,32 @@ mod tests {
     }
 
     #[test]
+    fn native_output_uses_async_ensure_initialized_with_sync_compat_helper() {
+        let ci = ComponentInterface::new("test_ns");
+        let config = Config::from(&ci);
+        let wrapper = DartWrapper::new(&ci, &config);
+        let output = render_tokens(wrapper.generate_native());
+
+        assert!(output.contains("void _runApiChecks()"));
+        assert!(output.contains("Future<void> ensureInitialized({String? wasmPath}) async"));
+        assert!(output.contains("@Deprecated(\"Use ensureInitialized instead\")"));
+        assert!(output.contains("void initialize()"));
+        assert!(output.contains("_runApiChecks();"));
+    }
+
+    #[test]
+    fn stub_output_only_exposes_async_ensure_initialized() {
+        let ci = ComponentInterface::new("test_ns");
+        let config = Config::from(&ci);
+        let wrapper = DartWrapper::new(&ci, &config);
+        let output = render_tokens(wrapper.generate_stub());
+
+        assert!(output.contains("Future<void> ensureInitialized({String? wasmPath}) async"));
+        assert!(!output.contains("@Deprecated(\"Use ensureInitialized instead\")"));
+        assert!(!output.contains("void initialize()"));
+    }
+
+    #[test]
     fn web_output_includes_js_interop_runtime() {
         let ci = ComponentInterface::from_webidl(
             r#"
@@ -988,7 +1013,7 @@ mod tests {
         assert_stub_export_hides(
             &output,
             "test_ns_stub.dart",
-            &["ensureInitialized", "initialize", "greet"],
+            &["ensureInitialized", "greet"],
         );
         assert!(output.contains("__uniffi_test_ns.init"));
         assert!(output.contains("__uniffi_test_ns.test_ns_greet"));
@@ -1093,11 +1118,7 @@ mod tests {
         let wrapper = DartWrapper::new(&ci, &config);
         let output = render_tokens(wrapper.generate_web().expect("web generation"));
 
-        assert_stub_export_hides(
-            &output,
-            "test_ns_stub.dart",
-            &["ensureInitialized", "initialize"],
-        );
+        assert_stub_export_hides(&output, "test_ns_stub.dart", &["ensureInitialized"]);
         assert!(!output.contains("__uniffi_test_ns.test_ns_signed_big"));
         assert!(!output.contains("__uniffi_test_ns.test_ns_unsigned_big"));
         assert!(!output.contains("JSBigInt"));
@@ -1120,7 +1141,6 @@ mod tests {
             "simple_fns_stub.dart",
             &[
                 "ensureInitialized",
-                "initialize",
                 "byteToU32",
                 "getInt",
                 "getString",

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -17,6 +17,7 @@ use uniffi_bindgen::Component;
 use self::render::Renderer;
 use self::types::TypeHelpersRenderer;
 use crate::gen::oracle::DartCodeOracle;
+use uniffi_bindgen::interface::AsType;
 use uniffi_bindgen::{BindingGenerator, ComponentInterface};
 
 mod callback_interface;
@@ -35,6 +36,10 @@ mod types;
 
 pub use code_type::CodeType;
 
+fn default_web_unsupported_policy() -> String {
+    "warn".to_string()
+}
+
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Config {
     package_name: Option<String>,
@@ -42,6 +47,13 @@ pub struct Config {
     #[serde(default)]
     external_packages: HashMap<String, String>,
     asset_id: Option<String>,
+    #[serde(default)]
+    generate_web: bool,
+    wasm_module_name: Option<String>,
+    #[serde(default)]
+    wasm_crate_features: Vec<String>,
+    #[serde(default = "default_web_unsupported_policy")]
+    web_unsupported_policy: String,
 }
 
 impl From<&ComponentInterface> for Config {
@@ -51,6 +63,10 @@ impl From<&ComponentInterface> for Config {
             cdylib_name: Some(ci.namespace().to_owned()),
             external_packages: HashMap::new(),
             asset_id: None,
+            generate_web: false,
+            wasm_module_name: None,
+            wasm_crate_features: Vec::new(),
+            web_unsupported_policy: default_web_unsupported_policy(),
         }
     }
 }
@@ -82,6 +98,24 @@ impl Config {
             format!("uniffi:{}", self.cdylib_name())
         }
     }
+
+    pub fn generate_web(&self) -> bool {
+        self.generate_web
+    }
+
+    pub fn wasm_module_name(&self) -> String {
+        self.wasm_module_name
+            .clone()
+            .unwrap_or_else(|| format!("__uniffi_{}", self.package_name()))
+    }
+
+    pub fn web_unsupported_policy(&self) -> &str {
+        &self.web_unsupported_policy
+    }
+
+    pub fn wasm_crate_features(&self) -> &[String] {
+        &self.wasm_crate_features
+    }
 }
 
 pub struct DartWrapper<'a> {
@@ -92,7 +126,7 @@ pub struct DartWrapper<'a> {
 
 impl<'a> DartWrapper<'a> {
     pub fn new(ci: &'a ComponentInterface, config: &'a Config) -> Self {
-        let type_renderer = TypeHelpersRenderer::new(ci);
+        let type_renderer = TypeHelpersRenderer::with_import_prefix(ci, "../".to_string());
         DartWrapper {
             ci,
             config,
@@ -100,7 +134,23 @@ impl<'a> DartWrapper<'a> {
         }
     }
 
-    fn generate(&self) -> dart::Tokens {
+    fn generate_entry_point(&self) -> dart::Tokens {
+        let ns = self.ci.namespace();
+        quote! {
+            export $(quoted(format!("src/{ns}_stub.dart")))
+              if (dart.library.ffi) $(quoted(format!("src/{ns}_native.dart")))
+              if (dart.library.js_interop) $(quoted(format!("src/{ns}_web.dart")));
+        }
+    }
+
+    fn generate_web_placeholder(&self) -> dart::Tokens {
+        let ns = self.ci.namespace();
+        quote! {
+            export $(quoted(format!("{ns}_stub.dart")));
+        }
+    }
+
+    fn generate_native(&self) -> dart::Tokens {
         let package_name = &self.config.package_name();
 
         let (type_helper_code, functions_definitions) = &self.type_renderer.render();
@@ -221,9 +271,397 @@ impl<'a> DartWrapper<'a> {
             }
         }
     }
+
+    fn generate_stub(&self) -> dart::Tokens {
+        let ns = self.ci.namespace();
+        let import_prefix = "../";
+
+        let modules_to_import = self
+            .ci
+            .iter_external_types()
+            .map(|ty| {
+                self.ci
+                    .namespace_for_type(ty)
+                    .expect("external type should have module_path")
+            })
+            .collect::<std::collections::BTreeSet<_>>();
+
+        let stub_imports = quote! {
+            import "dart:async";
+            import "dart:typed_data";
+            $( for imp in &modules_to_import {
+                $(format!("import \"{}{}.dart\"", import_prefix, imp));
+            })
+        };
+
+        let record_stubs = self.generate_stub_records();
+        let enum_stubs = self.generate_stub_enums();
+        let object_stubs = self.generate_stub_objects();
+        let function_stubs = self.generate_stub_functions();
+        let callback_stubs = self.generate_stub_callback_interfaces();
+        let stream_stubs = self.generate_stub_streams();
+
+        quote! {
+            $stub_imports
+
+            $record_stubs
+
+            $enum_stubs
+
+            $callback_stubs
+
+            $object_stubs
+
+            $function_stubs
+
+            $stream_stubs
+
+            void ensureInitialized() {
+                throw UnsupportedError($(quoted(format!("{ns} is not supported on this platform"))));
+            }
+
+            @Deprecated("Use ensureInitialized instead")
+            void initialize() {
+                throw UnsupportedError($(quoted(format!("{ns} is not supported on this platform"))));
+            }
+        }
+    }
+
+    fn generate_stub_records(&self) -> dart::Tokens {
+        let mut tokens = quote!();
+        for rec in self.ci.record_definitions() {
+            let cls_name = DartCodeOracle::class_name(rec.name());
+            let fields: Vec<dart::Tokens> = rec
+                .fields()
+                .iter()
+                .map(|f| {
+                    let field_name = DartCodeOracle::var_name(f.name());
+                    let field_type = types::generate_type(&f.as_type());
+                    quote!(final $field_type $field_name;)
+                })
+                .collect();
+            let constructor_params: Vec<dart::Tokens> = rec
+                .fields()
+                .iter()
+                .map(|f| {
+                    let field_name = DartCodeOracle::var_name(f.name());
+                    quote!(required this.$field_name)
+                })
+                .collect();
+            let constructor = if rec.fields().is_empty() {
+                quote!($(&cls_name)();)
+            } else {
+                quote!($(&cls_name)({$(for p in constructor_params => $p, )});)
+            };
+            tokens.append(quote! {
+                class $(&cls_name) {
+                    $(for f in fields => $f)
+                    $constructor
+                }
+            });
+        }
+        tokens
+    }
+
+    fn generate_stub_enums(&self) -> dart::Tokens {
+        let mut tokens = quote!();
+        for enm in self.ci.enum_definitions() {
+            let cls_name = DartCodeOracle::class_name(enm.name());
+            let is_error = self.ci.is_name_used_as_error(enm.name());
+            let implements_exception = if is_error {
+                quote!( implements Exception)
+            } else {
+                quote!()
+            };
+
+            if enm.is_flat() {
+                tokens.append(quote! {
+                    enum $(&cls_name) $(&implements_exception) {
+                        $(for v in enm.variants() =>
+                            $(DartCodeOracle::enum_variant_name(v.name())),)
+                        ;
+                    }
+                });
+            } else {
+                tokens.append(quote! {
+                    abstract class $(&cls_name) $(&implements_exception) {}
+                });
+                for variant in enm.variants() {
+                    let variant_cls = format!(
+                        "{}{}",
+                        DartCodeOracle::class_name(variant.name()),
+                        &cls_name
+                    );
+                    let field_decls: Vec<dart::Tokens> = variant
+                        .fields()
+                        .iter()
+                        .enumerate()
+                        .map(|(i, f)| {
+                            let name = if f.name().is_empty() {
+                                format!("v{i}")
+                            } else {
+                                DartCodeOracle::var_name(f.name())
+                            };
+                            let ty = types::generate_type(&f.as_type());
+                            quote!(final $ty $name;)
+                        })
+                        .collect();
+                    let ctor_params: Vec<dart::Tokens> = variant
+                        .fields()
+                        .iter()
+                        .enumerate()
+                        .map(|(i, f)| {
+                            let name = if f.name().is_empty() {
+                                format!("v{i}")
+                            } else {
+                                DartCodeOracle::var_name(f.name())
+                            };
+                            if variant.fields().len() > 1 {
+                                quote!(required this.$name)
+                            } else {
+                                quote!(this.$name)
+                            }
+                        })
+                        .collect();
+                    let ctor_list = if variant.fields().len() > 1 {
+                        quote!({$(for p in ctor_params => $p, )})
+                    } else {
+                        quote!($(for p in ctor_params => $p, ))
+                    };
+                    let to_string_method: dart::Tokens = if is_error {
+                        quote! {
+                            @override
+                            String toString() { return $(quoted(&variant_cls)); }
+                        }
+                    } else {
+                        quote!()
+                    };
+                    tokens.append(quote! {
+                        class $(&variant_cls) extends $(&cls_name) {
+                            $(for f in &field_decls => $f)
+                            $(&variant_cls)($ctor_list);
+                            $to_string_method
+                        }
+                    });
+                }
+            }
+        }
+        tokens
+    }
+
+    fn generate_stub_objects(&self) -> dart::Tokens {
+        let mut tokens = quote!();
+        for obj in self.ci.object_definitions() {
+            let cls_name = DartCodeOracle::class_name(obj.name());
+
+            if obj.has_callback_interface() {
+                let methods: Vec<dart::Tokens> = obj
+                    .methods()
+                    .iter()
+                    .map(|m| {
+                        let method_name = DartCodeOracle::fn_name(m.name());
+                        let ret = stub_return_type(m.return_type(), m.is_async());
+                        let params = stub_method_params(&m.arguments());
+                        quote!($ret $method_name($params);)
+                    })
+                    .collect();
+                tokens.append(quote! {
+                    abstract class $(&cls_name) {
+                        $(for m in methods => $m)
+                    }
+                });
+                continue;
+            }
+
+            if obj.is_trait_interface() {
+                let methods: Vec<dart::Tokens> = obj
+                    .methods()
+                    .iter()
+                    .map(|m| {
+                        let method_name = DartCodeOracle::fn_name(m.name());
+                        let ret = stub_return_type(m.return_type(), m.is_async());
+                        let params = stub_method_params(&m.arguments());
+                        quote!($ret $method_name($params);)
+                    })
+                    .collect();
+                tokens.append(quote! {
+                    abstract class $(&cls_name) {
+                        void dispose();
+                        $(for m in methods => $m)
+                    }
+                });
+                continue;
+            }
+
+            let interface_name = DartCodeOracle::object_interface_name(self.ci, obj);
+
+            let interface_method_sigs: Vec<dart::Tokens> = obj
+                .methods()
+                .iter()
+                .map(|m| {
+                    let method_name = DartCodeOracle::fn_name(m.name());
+                    let ret = stub_return_type(m.return_type(), m.is_async());
+                    let params = stub_method_params(&m.arguments());
+                    quote!($ret $method_name($params);)
+                })
+                .collect();
+
+            tokens.append(quote! {
+                abstract class $(&interface_name) {
+                    void dispose();
+                    $(for m in &interface_method_sigs => $m)
+                }
+            });
+
+            let unsupported = format!("{cls_name} is not supported on this platform");
+            let mut ctor_stubs = Vec::new();
+            for ctor in obj.constructors() {
+                let ctor_name = ctor.name();
+                let params = stub_method_params(&ctor.arguments());
+                if ctor.is_async() {
+                    if ctor_name == "new" {
+                        ctor_stubs.push(quote! {
+                            static Future<$(&cls_name)> new_($params) =>
+                                throw UnsupportedError($(quoted(&unsupported)));
+                        });
+                    } else {
+                        ctor_stubs.push(quote! {
+                            static Future<$(&cls_name)> $(DartCodeOracle::fn_name(ctor_name))($params) =>
+                                throw UnsupportedError($(quoted(&unsupported)));
+                        });
+                    }
+                } else if ctor_name == "new" {
+                    ctor_stubs.push(quote! {
+                        $(&cls_name)($params) { throw UnsupportedError($(quoted(&unsupported))); }
+                    });
+                } else {
+                    ctor_stubs.push(quote! {
+                        $(&cls_name).$(DartCodeOracle::fn_name(ctor_name))($params) { throw UnsupportedError($(quoted(&unsupported))); }
+                    });
+                }
+            }
+
+            let method_stubs: Vec<dart::Tokens> = obj
+                .methods()
+                .iter()
+                .map(|m| {
+                    let method_name = DartCodeOracle::fn_name(m.name());
+                    let ret = stub_return_type(m.return_type(), m.is_async());
+                    let params = stub_method_params(&m.arguments());
+                    quote!($ret $method_name($params) => throw UnsupportedError($(quoted(&unsupported)));)
+                })
+                .collect();
+
+            let is_error = self.ci.is_name_used_as_error(obj.name());
+            let error_impl = if is_error {
+                quote!( implements $(&interface_name), Exception)
+            } else {
+                quote!( implements $(&interface_name))
+            };
+
+            tokens.append(quote! {
+                class $(&cls_name) $error_impl {
+                    $(for c in ctor_stubs => $c)
+                    $(for m in method_stubs => $m)
+                    void dispose() => throw UnsupportedError($(quoted(&unsupported)));
+                }
+            });
+        }
+        tokens
+    }
+
+    fn generate_stub_functions(&self) -> dart::Tokens {
+        let mut tokens = quote!();
+        for func in self.ci.function_definitions() {
+            let fn_name = DartCodeOracle::fn_name(func.name());
+            let ret = stub_return_type(func.return_type(), func.is_async());
+            let params = stub_method_params(&func.arguments());
+            let msg = format!("{fn_name} is not supported on this platform");
+            tokens.append(quote! {
+                $ret $fn_name($params) => throw UnsupportedError($(quoted(msg)));
+            });
+        }
+        tokens
+    }
+
+    fn generate_stub_callback_interfaces(&self) -> dart::Tokens {
+        let mut tokens = quote!();
+        for cb in self.ci.callback_interface_definitions() {
+            let cls_name = DartCodeOracle::class_name(cb.name());
+            let methods: Vec<dart::Tokens> = cb
+                .methods()
+                .iter()
+                .map(|m| {
+                    let method_name = DartCodeOracle::fn_name(m.name());
+                    let ret = stub_return_type(m.return_type(), m.is_async());
+                    let params = stub_method_params(&m.arguments());
+                    quote!($ret $method_name($params);)
+                })
+                .collect();
+            tokens.append(quote! {
+                abstract class $(&cls_name) {
+                    $(for m in methods => $m)
+                }
+            });
+        }
+        tokens
+    }
+
+    fn generate_stub_streams(&self) -> dart::Tokens {
+        let mut tokens = quote!();
+        for obj in self.ci.object_definitions() {
+            if obj.name().contains("StreamExt") {
+                let fn_name = DartCodeOracle::fn_name(&obj.name().replace("StreamExt", ""));
+                let msg = format!("{fn_name} is not supported on this platform");
+                tokens.append(quote! {
+                    $fn_name() async* {
+                        throw UnsupportedError($(quoted(msg)));
+                    }
+                });
+            }
+        }
+        tokens
+    }
+}
+
+fn stub_return_type(
+    return_type: Option<&uniffi_bindgen::interface::Type>,
+    is_async: bool,
+) -> dart::Tokens {
+    let base = if let Some(ret) = return_type {
+        types::generate_type(ret)
+    } else {
+        quote!(void)
+    };
+    if is_async {
+        quote!(Future<$base>)
+    } else {
+        base
+    }
+}
+
+fn stub_method_params(args: &[&uniffi_bindgen::interface::Argument]) -> dart::Tokens {
+    if args.is_empty() {
+        return quote!();
+    }
+    quote!({$(for arg in args =>
+        required $(types::generate_type(&arg.as_type())) $(DartCodeOracle::var_name(arg.name())),
+    )})
 }
 
 pub struct DartBindingGenerator;
+
+fn write_dart_file(path: &Utf8Path, tokens: dart::Tokens, try_format_code: bool) -> Result<()> {
+    let file = std::fs::File::create(path)?;
+    let mut w = fmt::IoWriter::new(file);
+    let mut fmt_cfg = fmt::Config::from_lang::<Dart>();
+    if try_format_code {
+        fmt_cfg = fmt_cfg.with_indentation(fmt::Indentation::Space(2));
+    }
+    let dart_cfg = dart::Config::default();
+    tokens.format_file(&mut w.as_formatter(&fmt_cfg), &dart_cfg)?;
+    Ok(())
+}
 
 impl BindingGenerator for DartBindingGenerator {
     type Config = Config;
@@ -234,19 +672,32 @@ impl BindingGenerator for DartBindingGenerator {
         components: &[uniffi_bindgen::Component<Self::Config>],
     ) -> Result<()> {
         for Component { ci, config, .. } in components {
-            let filename = settings.out_dir.join(format!("{}.dart", ci.namespace()));
-            let tokens = DartWrapper::new(ci, config).generate();
-            let file = std::fs::File::create(filename)?;
+            let ns = ci.namespace();
+            let wrapper = DartWrapper::new(ci, config);
 
-            let mut w = fmt::IoWriter::new(file);
+            let src_dir = settings.out_dir.join("src");
+            std::fs::create_dir_all(&src_dir)?;
 
-            let mut fmt = fmt::Config::from_lang::<Dart>();
-            if settings.try_format_code {
-                fmt = fmt.with_indentation(fmt::Indentation::Space(2));
-            }
-            let config = dart::Config::default();
-
-            tokens.format_file(&mut w.as_formatter(&fmt), &config)?;
+            write_dart_file(
+                &settings.out_dir.join(format!("{ns}.dart")),
+                wrapper.generate_entry_point(),
+                settings.try_format_code,
+            )?;
+            write_dart_file(
+                &src_dir.join(format!("{ns}_native.dart")),
+                wrapper.generate_native(),
+                settings.try_format_code,
+            )?;
+            write_dart_file(
+                &src_dir.join(format!("{ns}_stub.dart")),
+                wrapper.generate_stub(),
+                settings.try_format_code,
+            )?;
+            write_dart_file(
+                &src_dir.join(format!("{ns}_web.dart")),
+                wrapper.generate_web_placeholder(),
+                settings.try_format_code,
+            )?;
         }
 
         // Run full Dart formatter on the output directory as a best-effort step.
@@ -424,5 +875,45 @@ pub fn generate_dart_bindings(
             None,
             true,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use genco::fmt;
+
+    fn render_tokens(tokens: dart::Tokens) -> String {
+        let mut buf = Vec::new();
+        {
+            let mut w = fmt::IoWriter::new(&mut buf);
+            let fmt_cfg = fmt::Config::from_lang::<Dart>();
+            let dart_cfg = dart::Config::default();
+            tokens
+                .format_file(&mut w.as_formatter(&fmt_cfg), &dart_cfg)
+                .expect("failed to render tokens");
+        }
+        String::from_utf8(buf).expect("non-UTF8 output")
+    }
+
+    #[test]
+    fn entry_point_ffi_precedes_js_interop() {
+        let ci = ComponentInterface::new("test_ns");
+        let config = Config::from(&ci);
+        let wrapper = DartWrapper::new(&ci, &config);
+        let output = render_tokens(wrapper.generate_entry_point());
+
+        let ffi_pos = output
+            .find("dart.library.ffi")
+            .expect("ffi selector missing from entry point");
+        let js_pos = output
+            .find("dart.library.js_interop")
+            .expect("js_interop selector missing from entry point");
+
+        assert!(
+            ffi_pos < js_pos,
+            "ffi must appear before js_interop for native-wins precedence, \
+             but ffi at {ffi_pos}, js_interop at {js_pos}.\nGenerated:\n{output}"
+        );
     }
 }

--- a/src/gen/objects.rs
+++ b/src/gen/objects.rs
@@ -639,11 +639,14 @@ fn generate_object_interface(
 
     if method_tokens.is_empty() {
         quote! {
-            abstract class $(interface_name) {}
+            abstract class $(interface_name) {
+                void dispose();
+            }
         }
     } else {
         quote! {
             abstract class $(interface_name) {
+                void dispose();
                 $(for method in method_tokens => $method)
             }
         }

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -13,6 +13,7 @@ type FunctionDefinition = dart::Tokens;
 
 pub struct TypeHelpersRenderer<'a> {
     ci: &'a ComponentInterface,
+    import_prefix: String,
     include_once_names: RefCell<BTreeMap<String, Type>>,
     // Tracks ad-hoc "include once" names that don't map to a concrete `Type`
     include_once_custom: RefCell<BTreeSet<String>>,
@@ -22,6 +23,7 @@ impl<'a> TypeHelpersRenderer<'a> {
     pub fn with_import_prefix(ci: &'a ComponentInterface, import_prefix: String) -> Self {
         Self {
             ci,
+            import_prefix,
             include_once_names: RefCell::new(BTreeMap::new()),
             include_once_custom: RefCell::new(BTreeSet::new()),
         }
@@ -538,7 +540,7 @@ mod tests {
     #[test]
     fn include_names_iterate_in_name_order() {
         let ci = ComponentInterface::new("determinism");
-        let renderer = TypeHelpersRenderer::new(&ci);
+        let renderer = TypeHelpersRenderer::with_import_prefix(&ci, String::new());
 
         renderer.include_once_check("z", &Type::String);
         renderer.include_once_check("a", &Type::UInt8);

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -16,14 +16,16 @@ pub struct TypeHelpersRenderer<'a> {
     include_once_names: RefCell<HashMap<String, Type>>,
     // Tracks ad-hoc "include once" names that don't map to a concrete `Type`
     include_once_custom: RefCell<HashSet<String>>,
+    import_prefix: String,
 }
 
 impl<'a> TypeHelpersRenderer<'a> {
-    pub fn new(ci: &'a ComponentInterface) -> Self {
+    pub fn with_import_prefix(ci: &'a ComponentInterface, import_prefix: String) -> Self {
         Self {
             ci,
             include_once_names: RefCell::new(HashMap::new()),
             include_once_custom: RefCell::new(HashSet::new()),
+            import_prefix,
         }
     }
 
@@ -93,11 +95,11 @@ impl Renderer<(FunctionDefinition, dart::Tokens)> for TypeHelpersRenderer<'_> {
                     .expect("external type should have module_path")
             })
             .collect::<BTreeSet<_>>();
-        // The second import statement uses a library prefix, to distinguish conflicting identifiers e.g. RustBuffer vs. ext.RustBuffer
+        let import_prefix = &self.import_prefix;
         let imports: dart::Tokens = quote!(
             $( for imp in modules_to_import {
-                $(format!("import \"{}.dart\"", imp));
-                $(format!("import \"{}.dart\"", imp)) as $imp;
+                $(format!("import \"{}{}.dart\"", import_prefix, imp));
+                $(format!("import \"{}{}.dart\"", import_prefix, imp)) as $imp;
             })
         );
 
@@ -551,9 +553,10 @@ pub fn generate_type(ty: &Type) -> dart::Tokens {
             value_type,
         } => quote!(Map<$(generate_type(key_type)), $(generate_type(value_type))>),
         Type::Enum { name, .. } => quote!($(DartCodeOracle::class_name(name))),
+        Type::Timestamp => quote!(DateTime),
         Type::Duration => quote!(Duration),
         Type::Record { name, .. } => quote!($name),
         Type::Custom { name, .. } => quote!($name),
-        _ => todo!("Type::{:?}", ty),
+        Type::CallbackInterface { name, .. } => quote!($name),
     }
 }

--- a/src/gen/web/functions.rs
+++ b/src/gen/web/functions.rs
@@ -1,0 +1,126 @@
+use genco::prelude::*;
+use heck::ToUpperCamelCase;
+use uniffi_bindgen::interface::{AsType, Function, Type};
+
+use crate::gen::oracle::DartCodeOracle;
+
+use super::oracle::WebCodeOracle;
+
+pub fn is_supported_function(func: &Function) -> bool {
+    !func.is_async()
+        && func.throws_type().is_none()
+        && func
+            .arguments()
+            .iter()
+            .all(|arg| is_supported_type(&arg.as_type()))
+        && func.return_type().map(is_supported_type).unwrap_or(true)
+}
+
+pub fn is_supported_type(type_: &Type) -> bool {
+    WebCodeOracle::dart_type_label(type_).is_some() && WebCodeOracle::js_type_label(type_).is_some()
+}
+
+pub fn uses_bytes(func: &Function) -> bool {
+    func.arguments()
+        .iter()
+        .any(|arg| matches!(arg.as_type(), Type::Bytes))
+        || func
+            .return_type()
+            .map(|ret| matches!(ret, Type::Bytes))
+            .unwrap_or(false)
+}
+
+pub fn generate_function(func: &Function, module_name: &str, namespace: &str) -> dart::Tokens {
+    let public_name = DartCodeOracle::fn_name(func.name());
+    let external_name = format!("_uniffiWeb{}", func.name().to_upper_camel_case());
+    let external_call_name = external_name.clone();
+    let js_export_name = format!(
+        "{}_{}",
+        namespace.replace('-', "_"),
+        func.name().replace('-', "_")
+    );
+
+    let public_args: Vec<dart::Tokens> = func
+        .arguments()
+        .iter()
+        .map(|arg| {
+            let arg_name = DartCodeOracle::var_name(arg.name());
+            let arg_type = WebCodeOracle::dart_type_label(&arg.as_type())
+                .expect("supported function argument should have Dart type");
+            quote!(required $arg_type $arg_name)
+        })
+        .collect();
+
+    let external_args: Vec<dart::Tokens> = func
+        .arguments()
+        .iter()
+        .map(|arg| {
+            let arg_name = DartCodeOracle::var_name(arg.name());
+            let arg_type = WebCodeOracle::js_type_label(&arg.as_type())
+                .expect("supported function argument should have JS type");
+            quote!($arg_type $arg_name)
+        })
+        .collect();
+
+    let call_args: Vec<dart::Tokens> = func
+        .arguments()
+        .iter()
+        .map(|arg| {
+            let arg_name = DartCodeOracle::var_name(arg.name());
+            WebCodeOracle::lower_expr(&arg.as_type(), quote!($arg_name))
+                .expect("supported function argument should lower")
+        })
+        .collect();
+
+    let public_params = if public_args.is_empty() {
+        quote!()
+    } else {
+        quote!({$(for arg in &public_args => $arg, )})
+    };
+    let external_params =
+        quote!($(for (i, arg) in external_args.iter().enumerate() => $(if i > 0 => , )$arg));
+    let call_params =
+        quote!($(for (i, arg) in call_args.iter().enumerate() => $(if i > 0 => , )$arg));
+
+    let (external_return, public_return, body) = if let Some(ret) = func.return_type() {
+        let external_return =
+            WebCodeOracle::js_type_label(ret).expect("supported return should have JS type");
+        let public_return =
+            WebCodeOracle::dart_type_label(ret).expect("supported return should have Dart type");
+        let lifted =
+            WebCodeOracle::lift_expr(ret, quote!(rawResult)).expect("supported return should lift");
+        (
+            external_return,
+            public_return,
+            quote! {
+                try {
+                    final rawResult = $(&external_call_name)($call_params);
+                    return $lifted;
+                } catch (error) {
+                    return _throwWebError(error);
+                }
+            },
+        )
+    } else {
+        (
+            quote!(void),
+            quote!(void),
+            quote! {
+                try {
+                    $(&external_call_name)($call_params);
+                } catch (error) {
+                    _throwWebError(error);
+                }
+            },
+        )
+    };
+
+    quote! {
+        @JS($(quoted(format!("{module_name}.{js_export_name}"))))
+        external $external_return $(&external_name)($external_params);
+
+        $public_return $(&public_name)($public_params) {
+            $body
+        }
+    }
+}

--- a/src/gen/web/mod.rs
+++ b/src/gen/web/mod.rs
@@ -1,0 +1,174 @@
+use anyhow::{bail, Result};
+use genco::prelude::*;
+use uniffi_bindgen::ComponentInterface;
+
+use crate::gen::Config;
+
+mod functions;
+mod oracle;
+mod types;
+
+pub struct WebDartWrapper<'a> {
+    ci: &'a ComponentInterface,
+    config: &'a Config,
+}
+
+impl<'a> WebDartWrapper<'a> {
+    pub fn new(ci: &'a ComponentInterface, config: &'a Config) -> Self {
+        Self { ci, config }
+    }
+
+    pub fn generate(&self) -> Result<dart::Tokens> {
+        let ns = self.ci.namespace();
+        let module_name = self.config.wasm_module_name(ns);
+        let supported_functions: Vec<_> = self
+            .ci
+            .function_definitions()
+            .iter()
+            .filter(|func| functions::is_supported_function(func))
+            .collect();
+
+        emit_unsupported_diagnostics(self.ci, self.config)?;
+
+        let mut hidden_names = vec!["ensureInitialized".to_string(), "initialize".to_string()];
+        hidden_names.extend(
+            supported_functions
+                .iter()
+                .map(|func| crate::gen::oracle::DartCodeOracle::fn_name(func.name())),
+        );
+        let stub_export = quote!(export $(quoted(format!("{ns}_stub.dart"))) hide $(for (i, name) in hidden_names.iter().enumerate() => $(if i > 0 => , )$name););
+
+        let function_tokens = quote! {
+            $(for func in &supported_functions =>
+                $(functions::generate_function(func, &module_name, ns))
+            )
+        };
+        let typed_data_import = if supported_functions
+            .iter()
+            .any(|func| functions::uses_bytes(func))
+        {
+            quote!(import "dart:typed_data";)
+        } else {
+            quote!()
+        };
+        let runtime = types::generate_web_runtime(&module_name);
+        let version_check = self.generate_version_check(&module_name);
+        let checksum_check = self.generate_checksum_check(&module_name);
+
+        Ok(quote! {
+            import "dart:async";
+            import "dart:js_interop";
+            $typed_data_import
+
+            $stub_export
+
+            $runtime
+
+            $version_check
+
+            $checksum_check
+
+            $function_tokens
+        })
+    }
+
+    fn generate_version_check(&self, module_name: &str) -> dart::Tokens {
+        let external_name = "_uniffiWebContractVersion";
+        let contract_version_fn = self.ci.ffi_uniffi_contract_version();
+        let js_name = contract_version_fn.name();
+        let bindings_version = self.ci.uniffi_contract_version();
+
+        quote! {
+            @JS($(quoted(format!("{module_name}.{js_name}"))))
+            external JSNumber $external_name();
+
+            void _checkApiVersion() {
+                final bindingsVersion = $bindings_version;
+                final scaffoldingVersion = $external_name().toDartInt;
+                if (bindingsVersion != scaffoldingVersion) {
+                    throw UniffiInternalError.panicked("UniFFI contract version mismatch: bindings version $bindingsVersion, scaffolding version $scaffoldingVersion");
+                }
+            }
+        }
+    }
+
+    fn generate_checksum_check(&self, module_name: &str) -> dart::Tokens {
+        let declarations = quote! {
+            $(for (name, _) in self.ci.iter_checksums() =>
+                @JS($(quoted(format!("{module_name}.{name}"))))
+                external JSNumber $(format!("_uniffiWebChecksum_{name}"))();
+            )
+        };
+        let checks = quote! {
+            $(for (name, expected_checksum) in self.ci.iter_checksums() =>
+                if ($(format!("_uniffiWebChecksum_{name}"))().toDartInt != $expected_checksum) {
+                    throw UniffiInternalError.panicked("UniFFI API checksum mismatch");
+                }
+            )
+        };
+
+        quote! {
+            $declarations
+
+            void _checkApiChecksums() {
+                $checks
+            }
+        }
+    }
+}
+
+pub fn unsupported_web_api_names(ci: &ComponentInterface) -> Vec<String> {
+    let mut unsupported: Vec<String> = ci
+        .function_definitions()
+        .iter()
+        .filter(|func| !functions::is_supported_function(func))
+        .map(|func| format!("function {}", func.name()))
+        .collect();
+
+    unsupported.extend(
+        ci.object_definitions()
+            .iter()
+            .map(|obj| format!("object {}", obj.name())),
+    );
+    unsupported.extend(
+        ci.callback_interface_definitions()
+            .iter()
+            .map(|callback| format!("callback interface {}", callback.name())),
+    );
+    unsupported
+}
+
+pub fn emit_unsupported_diagnostics(ci: &ComponentInterface, config: &Config) -> Result<()> {
+    let unsupported = unsupported_web_api_names(ci);
+    if unsupported.is_empty() {
+        return Ok(());
+    }
+
+    let message = format!(
+        "unsupported web APIs for namespace '{}': {}",
+        ci.namespace(),
+        unsupported.join(", ")
+    );
+
+    if config.web_unsupported_policy() == "error" {
+        bail!("{message}");
+    }
+
+    println!("WARNING: {message}");
+    Ok(())
+}
+
+pub fn validate_unique_wasm_module_names<I>(modules: I) -> Result<()>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    let mut seen = std::collections::HashMap::new();
+    for (namespace, module_name) in modules {
+        if let Some(previous_namespace) = seen.insert(module_name.clone(), namespace.clone()) {
+            bail!(
+                "Duplicate wasm_module_name `{module_name}` for namespaces `{previous_namespace}` and `{namespace}`. Configure a distinct wasm_module_name for one component."
+            );
+        }
+    }
+    Ok(())
+}

--- a/src/gen/web/mod.rs
+++ b/src/gen/web/mod.rs
@@ -30,7 +30,7 @@ impl<'a> WebDartWrapper<'a> {
 
         emit_unsupported_diagnostics(self.ci, self.config)?;
 
-        let mut hidden_names = vec!["ensureInitialized".to_string(), "initialize".to_string()];
+        let mut hidden_names = vec!["ensureInitialized".to_string()];
         hidden_names.extend(
             supported_functions
                 .iter()

--- a/src/gen/web/oracle.rs
+++ b/src/gen/web/oracle.rs
@@ -1,0 +1,68 @@
+use genco::prelude::*;
+use uniffi_bindgen::interface::Type;
+
+pub struct WebCodeOracle;
+
+impl WebCodeOracle {
+    pub fn dart_type_label(type_: &Type) -> Option<dart::Tokens> {
+        match type_ {
+            Type::Boolean => Some(quote!(bool)),
+            Type::Int8 | Type::UInt8 | Type::Int16 | Type::UInt16 | Type::Int32 | Type::UInt32 => {
+                Some(quote!(int))
+            }
+            Type::Int64 | Type::UInt64 => None,
+            Type::Float32 | Type::Float64 => Some(quote!(double)),
+            Type::String => Some(quote!(String)),
+            Type::Bytes => Some(quote!(Uint8List)),
+            _ => None,
+        }
+    }
+
+    pub fn js_type_label(type_: &Type) -> Option<dart::Tokens> {
+        match type_ {
+            Type::Boolean => Some(quote!(JSBoolean)),
+            Type::Int8
+            | Type::UInt8
+            | Type::Int16
+            | Type::UInt16
+            | Type::Int32
+            | Type::UInt32
+            | Type::Float32
+            | Type::Float64 => Some(quote!(JSNumber)),
+            Type::Int64 | Type::UInt64 => None,
+            Type::String => Some(quote!(JSString)),
+            Type::Bytes => Some(quote!(JSUint8Array)),
+            _ => None,
+        }
+    }
+
+    pub fn lower_expr(type_: &Type, expr: dart::Tokens) -> Option<dart::Tokens> {
+        match type_ {
+            Type::Boolean
+            | Type::Int8
+            | Type::UInt8
+            | Type::Int16
+            | Type::UInt16
+            | Type::Int32
+            | Type::UInt32
+            | Type::Float32
+            | Type::Float64
+            | Type::String
+            | Type::Bytes => Some(quote!($expr.toJS)),
+            Type::Int64 | Type::UInt64 => None,
+            _ => None,
+        }
+    }
+
+    pub fn lift_expr(type_: &Type, expr: dart::Tokens) -> Option<dart::Tokens> {
+        match type_ {
+            Type::Boolean | Type::String | Type::Bytes => Some(quote!($expr.toDart)),
+            Type::Int8 | Type::UInt8 | Type::Int16 | Type::UInt16 | Type::Int32 | Type::UInt32 => {
+                Some(quote!($expr.toDartInt))
+            }
+            Type::Int64 | Type::UInt64 => None,
+            Type::Float32 | Type::Float64 => Some(quote!($expr.toDartDouble)),
+            _ => None,
+        }
+    }
+}

--- a/src/gen/web/types.rs
+++ b/src/gen/web/types.rs
@@ -1,0 +1,97 @@
+use genco::prelude::*;
+
+pub fn generate_web_runtime(module_name: &str) -> dart::Tokens {
+    quote! {
+        @JS($(quoted(format!("{module_name}.init"))))
+        external JSPromise<JSAny?> _uniffiWasmInit(JSString wasmUrl);
+
+        Future<void>? _initFuture;
+        bool _initialized = false;
+        String? _initializedWasmPath;
+
+        Future<void> ensureInitialized({String? wasmPath}) {
+            if (!_initialized && _initFuture == null && wasmPath == null) {
+                throw ArgumentError("wasmPath is required for the first successful web initialization");
+            }
+
+            if (_initialized) {
+                if (_initializedWasmPath != null && wasmPath != null && wasmPath != _initializedWasmPath) {
+                    throw StateError("UniFFI web module already initialized with a different wasmPath");
+                }
+                return Future.value();
+            }
+
+            final existing = _initFuture;
+            if (existing != null) {
+                if (_initializedWasmPath != null && wasmPath != null && wasmPath != _initializedWasmPath) {
+                    throw StateError("UniFFI web module initialization already in flight with a different wasmPath");
+                }
+                return existing;
+            }
+
+            _initializedWasmPath = wasmPath;
+            final future = _doInitialize(wasmPath: wasmPath!).then((_) {
+                _initialized = true;
+            }).catchError((error, stack) {
+                _initFuture = null;
+                _initializedWasmPath = null;
+                throw error;
+            });
+
+            _initFuture = future;
+            return future;
+        }
+
+        Future<void> _doInitialize({required String wasmPath}) async {
+            await _uniffiWasmInit(wasmPath.toJS).toDart;
+            _checkApiVersion();
+            _checkApiChecksums();
+        }
+
+        extension type _UniffiWebError(JSObject _) implements JSObject {
+            external String? get kind;
+            external String? get typeName;
+            external JSUint8Array? get payload;
+            external String? get message;
+        }
+
+        class UniffiInternalError implements Exception {
+            static const int rustPanic = 8;
+
+            final int errorCode;
+            final String? panicMessage;
+
+            const UniffiInternalError(this.errorCode, this.panicMessage);
+
+            static UniffiInternalError panicked(String message) {
+                return UniffiInternalError(rustPanic, message);
+            }
+
+            @override
+            String toString() {
+                return "UniFfi::rustPanic: " + (panicMessage ?? "");
+            }
+        }
+
+        Never _throwWebError(Object error) {
+            throw _decodeWebError(error);
+        }
+
+        Exception _decodeWebError(Object error) {
+            try {
+                final envelope = _UniffiWebError(error as JSObject);
+                switch (envelope.kind) {
+                    case "uniffi_error":
+                        return UniffiInternalError.panicked("UniFFI error " + (envelope.typeName ?? "unknown"));
+                    case "uniffi_internal":
+                    case "uniffi_panic":
+                        return UniffiInternalError.panicked(envelope.message ?? "Rust panic");
+                }
+            } catch (_) {
+                // Fall through to the generic conversion below.
+            }
+
+            return UniffiInternalError.panicked(error.toString());
+        }
+    }
+}


### PR DESCRIPTION
This PR resolves [#106](https://github.com/Uniffi-Dart/uniffi-dart/issues/106).

Notes to reviewers:
In Scope:
- Sync functions (all types: primitives, strings, bytes, records, enums, optionals, sequences, maps)
- Objects (constructors, methods, explicit `dispose()`, best-effort `FinalizationRegistry` fallback)
- Async functions (Rust futures exposed as `JSPromise` via `wasm_bindgen_futures`, converted to Dart `Future` via `.toDart`)
- Both UDL and proc-macro input modes (the shim wraps C-ABI symbols, which are identical regardless of input mode)

Out of this pr scope, until this effort is proven:
- Callback interfaces
- Callback trait objects
- Async callbacks
- Streams

New features

- [ ] Dual-target binding layout via conditional exports (`*_native.dart`, `*_web.dart`, `*_stub.dart`)
- [ ] Stub generation that preserves public API shapes but throws `UnsupportedError` on unsupported platforms