### PR TITLE
Prepare v0.2.0+v0.31.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to uniffi-dart will be documented in this file.
 
+## v0.2.0+v0.31.1
+
+### Breaking changes
+
+- **BREAKING**: Upgrade uniffi-rs from v0.30.0 to v0.31.1 (#125)
+
+### Fixes
+
+- Generate FfiConverter for Sequence/Optional of records in callback interfaces (#117)
+- Fix Dart error object renaming (#120)
+- Use Optional FfiConverter's `lower()` for inner types to avoid double-wrapping nullable records in callback return values (#121)
+- Make nullable record fields optional in Dart constructors (#122)
+
 ## v0.1.0+v0.30.0
 
 Initial release of uniffi-dart targeting uniffi-rs v0.30.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-dart"
-version = "0.1.0+v0.30.0"
+version = "0.2.0+v0.31.1"
 edition = "2021"
 license = "Apache-2 or MIT"
 homepage = "https://github.com/acterglobal/uniffi-dart"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add uniffi-dart as a dependency in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-uniffi-dart = "0.1.0+v0.30.0"
+uniffi-dart = "0.2.0+v0.31.1"
 ```
 
 ## Testing & Fixtures
@@ -80,7 +80,8 @@ uniffi-dart version and `A.B.C` is the targeted uniffi-rs version.
 
 | uniffi-rs target | Latest uniffi-dart release |
 |------------------|----------------------------|
-| v0.30.0          | v0.1.0+v0.30.0             |
+| v0.31.1          | v0.2.0+v0.31.1             |
+| v0.30.0          | v0.1.1+v0.30.0             |
 
 ## License & Credits
 

--- a/uniffi_dart_macro/Cargo.toml
+++ b/uniffi_dart_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_dart_macro"
-version = "0.1.0+v0.30.0"
+version = "0.2.0+v0.31.1"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Release PR for v0.2.0+v0.31.1, the first release on the
`release/uniffi-v0.31.x` line. Closes #130 (once tagged).

## Changes

- Bump `uniffi-dart` and `uniffi_dart_macro` versions to `0.2.0+v0.31.1`
- Update the README install snippet and versioning table
- Add a CHANGELOG entry covering the uniffi-rs bump and fixes landed since `v0.1.0+v0.30.0`

## Breaking changes

- **BREAKING**: Upgrade uniffi-rs from v0.30.0 to v0.31.1 (#125)

## Fixes included

- Generate FfiConverter for Sequence/Optional of records in callback interfaces (#117)
- Fix Dart error object renaming (#120)
- Use Optional FfiConverter's `lower()` for inner types to avoid double-wrapping nullable records in callback return values (#121)
- Make nullable record fields optional in Dart constructors (#122)

## Test plan

- [x] `cargo nextest run --all --nocapture` passes locally (22 tests, 0 failures)
- [ ] CI green