### PR TITLE
fix: make generated dart helper ordering deterministic

### DIFF
--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -1,5 +1,5 @@
-use std::collections::{BTreeSet, HashSet};
-use std::{cell::RefCell, collections::HashMap};
+use std::cell::RefCell;
+use std::collections::{BTreeMap, BTreeSet};
 
 use genco::prelude::*;
 use uniffi_bindgen::interface::AsType;
@@ -13,21 +13,21 @@ type FunctionDefinition = dart::Tokens;
 
 pub struct TypeHelpersRenderer<'a> {
     ci: &'a ComponentInterface,
-    include_once_names: RefCell<HashMap<String, Type>>,
+    include_once_names: RefCell<BTreeMap<String, Type>>,
     // Tracks ad-hoc "include once" names that don't map to a concrete `Type`
-    include_once_custom: RefCell<HashSet<String>>,
+    include_once_custom: RefCell<BTreeSet<String>>,
 }
 
 impl<'a> TypeHelpersRenderer<'a> {
     pub fn new(ci: &'a ComponentInterface) -> Self {
         Self {
             ci,
-            include_once_names: RefCell::new(HashMap::new()),
-            include_once_custom: RefCell::new(HashSet::new()),
+            include_once_names: RefCell::new(BTreeMap::new()),
+            include_once_custom: RefCell::new(BTreeSet::new()),
         }
     }
 
-    pub fn get_include_names(&self) -> HashMap<String, Type> {
+    pub fn get_include_names(&self) -> BTreeMap<String, Type> {
         self.include_once_names.clone().into_inner()
     }
 }
@@ -526,6 +526,24 @@ impl Renderer<(FunctionDefinition, dart::Tokens)> for TypeHelpersRenderer<'_> {
         };
 
         (types_helper_code, function_definitions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn include_names_iterate_in_name_order() {
+        let ci = ComponentInterface::new("determinism");
+        let renderer = TypeHelpersRenderer::new(&ci);
+
+        renderer.include_once_check("z", &Type::String);
+        renderer.include_once_check("a", &Type::UInt8);
+        renderer.include_once_check("m", &Type::Boolean);
+
+        let names: Vec<_> = renderer.get_include_names().keys().cloned().collect();
+        assert_eq!(names, ["a", "m", "z"]);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #133 

Makes Dart helper converter generation deterministic by storing include once helper names in ordered collections.

Previously, `TypeHelpersRenderer` tracked helper types with `HashMap`/`HashSet` and rendered by iterating that map. Since Rust hash collection iteration order is not stable between processes, repeated generation could reorder `FfiConverter*` helper declarations and create noisy generated diffs.

This switches the helper registry to `BTreeMap`/`BTreeSet` and adds a regression test for sorted helper name iteration.

I also sanity checked Mozilla’s built in UniFFI generators. Swift/Kotlin/Ruby render helper definitions via `ci.iter_local_types()`, which comes from UniFFI’s ordered `TypeUniverse` (`BTreeSet`). So this change aligns Dart helper rendering with the deterministic ordering pattern used by the upstream generators rather than preserving plugin specific hash map iteration.
