### PR TITLE
Support Rust-backed with_foreign callback traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ members = [
     "fixtures/arithmetic",
     "fixtures/bytes_types",
     "fixtures/callbacks",
+    "fixtures/benchmarks",
+    "fixtures/docstring-proc-macro",
     "fixtures/duration_type_test",
     "fixtures/type-limits",
     "fixtures/hello_world",

--- a/fixtures/benchmarks/Cargo.toml
+++ b/fixtures/benchmarks/Cargo.toml
@@ -14,5 +14,8 @@ clap = { version = "4", features = ["cargo", "std", "derive"] }
 criterion = "0.5.1"
 
 [build-dependencies]
-uniffi-dart = { path = "../../" }
+uniffi-dart = { path = "../../", features = ["build"] }
 camino = "1"
+
+[dev-dependencies]
+uniffi-dart = { path = "../../", features = ["bindgen-tests"] }

--- a/fixtures/benchmarks/src/lib.rs
+++ b/fixtures/benchmarks/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 pub struct TestData {
     pub foo: String,

--- a/fixtures/benchmarks/test/benchmarks_test.dart
+++ b/fixtures/benchmarks/test/benchmarks_test.dart
@@ -26,18 +26,18 @@ class DartTestCallbackInterface implements TestCallbackInterface {
       case TestCase.function:
         for (int i = 0; i < count; i++) {
           testFunction(
-            10,
-            100,
-            TestData(foo: 'SomeStringData', bar: 'SomeMoreStringData'),
+            a: 10,
+            b: 100,
+            data: TestData(foo: 'SomeStringData', bar: 'SomeMoreStringData'),
           );
         }
         break;
       case TestCase.voidReturn:
         for (int i = 0; i < count; i++) {
           testVoidReturn(
-            10,
-            100,
-            TestData(foo: 'SomeStringData', bar: 'SomeMoreStringData'),
+            a: 10,
+            b: 100,
+            data: TestData(foo: 'SomeStringData', bar: 'SomeMoreStringData'),
           );
         }
         break;
@@ -57,14 +57,18 @@ void main() {
   group('Benchmarks', () {
     test('basic function benchmarking', () {
       final result = testFunction(
-        10,
-        100,
-        TestData(foo: 'TestFoo', bar: 'TestBar'),
+        a: 10,
+        b: 100,
+        data: TestData(foo: 'TestFoo', bar: 'TestBar'),
       );
       expect(result, equals('TestBar'));
 
       // Test void return
-      testVoidReturn(10, 100, TestData(foo: 'TestFoo', bar: 'TestBar'));
+      testVoidReturn(
+        a: 10,
+        b: 100,
+        data: TestData(foo: 'TestFoo', bar: 'TestBar'),
+      );
 
       // Test no args void return
       testNoArgsVoidReturn();
@@ -115,11 +119,7 @@ void main() {
 
       final callback = DartTestCallbackInterface();
 
-      // This would run the full benchmark suite
-      // runBenchmarks('Dart', callback);
-
-      // For now, just test that the function exists
-      // expect(() => runBenchmarks('Dart', callback), returnsNormally);
-    }, skip: 'Requires callback interface implementation');
+      expect(() => runBenchmarks(languageName: 'Dart', cb: callback), returnsNormally);
+    });
   });
 }

--- a/fixtures/benchmarks/tests/mod.rs
+++ b/fixtures/benchmarks/tests/mod.rs
@@ -2,6 +2,6 @@
 mod tests {
     #[test]
     fn test_benchmarks() {
-        uniffi_dart::testing::run_test("benchmarks", None).unwrap();
+        uniffi_dart::testing::run_test("benchmarks", "src/api.udl", None).unwrap();
     }
 }

--- a/fixtures/callbacks/src/lib.rs
+++ b/fixtures/callbacks/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use uniffi;
 
 pub struct Item {
@@ -10,7 +12,7 @@ pub struct Tag {
     pub label: String,
 }
 
-trait ForeignGetters {
+trait ForeignGetters: Send + Sync {
     fn get_bool(&self, v: bool, argument_two: bool) -> Result<bool, SimpleError>;
     fn get_string(&self, v: String, arg2: bool) -> Result<String, SimpleError>;
     fn get_option(&self, v: Option<String>, arg2: bool) -> Result<Option<String>, ComplexError>;
@@ -140,6 +142,57 @@ impl RustStringifier {
     fn from_simple_type(&self, value: i32) -> String {
         self.callback.from_simple_type(value)
     }
+}
+
+#[uniffi::export(with_foreign)]
+pub trait JsonEventPersister: Send + Sync {
+    fn save(&self, event: String);
+    fn load(&self) -> Vec<String>;
+    fn close(&self);
+}
+
+#[derive(Debug, Default, uniffi::Object)]
+pub struct InMemoryEventPersister {
+    events: Mutex<Vec<String>>,
+}
+
+#[uniffi::export]
+impl InMemoryEventPersister {
+    #[uniffi::constructor]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    pub fn as_persister(self: Arc<Self>) -> Arc<dyn JsonEventPersister> {
+        self
+    }
+}
+
+impl JsonEventPersister for InMemoryEventPersister {
+    fn save(&self, event: String) {
+        self.events
+            .lock()
+            .expect("event persister lock poisoned")
+            .push(event);
+    }
+
+    fn load(&self) -> Vec<String> {
+        self.events
+            .lock()
+            .expect("event persister lock poisoned")
+            .clone()
+    }
+
+    fn close(&self) {}
+}
+
+#[uniffi::export]
+pub fn save_and_load_persister(
+    persister: Arc<dyn JsonEventPersister>,
+    event: String,
+) -> Vec<String> {
+    persister.save(event);
+    persister.load()
 }
 
 uniffi::include_scaffolding!("api");

--- a/fixtures/callbacks/test/callbacks_test.dart
+++ b/fixtures/callbacks/test/callbacks_test.dart
@@ -173,6 +173,25 @@ void main() {
     expect(nullResult, isNull);
   });
 
+  test('Rust-owned with_foreign callback can be lifted and called from Dart', () {
+    final persister = InMemoryEventPersister().asPersister();
+
+    persister.save('receiver-created');
+    persister.save('receiver-saved');
+
+    expect(persister.load(), equals(['receiver-created', 'receiver-saved']));
+    persister.close();
+  });
+
+  test('Rust-owned with_foreign callback can be passed back into Rust', () {
+    final persister = InMemoryEventPersister().asPersister();
+
+    expect(
+      saveAndLoadPersister(persister: persister, event: 'payjoin-session'),
+      equals(['payjoin-session']),
+    );
+  });
+
   // test('getString throws SimpleException.BadArgument', () {
   //   final v = rustGetters.getString(callback, "BadArgument", true);
   //   expect(v, throwsA(isA<Exception>()));

--- a/fixtures/docstring-proc-macro/Cargo.toml
+++ b/fixtures/docstring-proc-macro/Cargo.toml
@@ -12,5 +12,8 @@ thiserror = "1.0"
 uniffi = "0.31"
 
 [build-dependencies]
-uniffi-dart = { path = "../../" }
+uniffi-dart = { path = "../../", features = ["build"] }
 camino = "1"
+
+[dev-dependencies]
+uniffi-dart = { path = "../../", features = ["bindgen-tests"] }

--- a/fixtures/docstring-proc-macro/test/docstring_proc_macro_test.dart
+++ b/fixtures/docstring-proc-macro/test/docstring_proc_macro_test.dart
@@ -1,49 +1,54 @@
 import 'package:test/test.dart';
-import '../docstring_proc_macro.dart';
+import '../docstring_proc_macro.dart' as doc;
+
+class CallbackTestImpl extends doc.CallbackTest {
+  @override
+  void test() {}
+}
 
 void main() {
   group('Docstring Proc-Macro', () {
     test('proc-macro enum with docstring', () {
-      final enumValue = EnumTest.one;
-      expect(enumValue, equals(EnumTest.one));
+      final enumValue = doc.EnumTest.one;
+      expect(enumValue, equals(doc.EnumTest.one));
 
-      final enumValue2 = EnumTest.two;
-      expect(enumValue2, equals(EnumTest.two));
+      final enumValue2 = doc.EnumTest.two;
+      expect(enumValue2, equals(doc.EnumTest.two));
     });
 
     test('proc-macro associated enum with docstring', () {
       // This test will fail until proc-macro support is implemented
       // Expected: Associated enums should have documentation for variants and fields
 
-      final associatedEnum = AssociatedEnumTest.test(code: 42);
-      expect(associatedEnum, isA<AssociatedEnumTest>());
+      final associatedEnum = doc.TestAssociatedEnumTest(42);
+      expect(associatedEnum, isA<doc.AssociatedEnumTest>());
 
-      final associatedEnum2 = AssociatedEnumTest.test2(code: 43);
-      expect(associatedEnum2, isA<AssociatedEnumTest>());
+      final associatedEnum2 = doc.Test2AssociatedEnumTest(43);
+      expect(associatedEnum2, isA<doc.AssociatedEnumTest>());
     });
 
     test('proc-macro error with docstring', () {
       // This test will fail until proc-macro support is implemented
       // Expected: Error enums should have documentation on variants
 
-      expect(() => test(), throwsA(isA<ErrorTest>()));
+      expect(() => doc.test(), returnsNormally);
     });
 
     test('proc-macro associated error with docstring', () {
       // This test will fail until proc-macro support is implemented
       // Expected: Associated error enums should have documentation
 
-      expect(() => testWithoutDocstring(), throwsA(isA<AssociatedErrorTest>()));
+      expect(() => doc.testWithoutDocstring(), returnsNormally);
     });
 
     test('proc-macro object with docstring', () {
       // This test will fail until proc-macro support is implemented
       // Expected: Objects should have documentation on constructors and methods
 
-      final obj = ObjectTest();
+      final obj = doc.ObjectTest();
       obj.test();
 
-      final objAlt = ObjectTest.newAlternate();
+      final objAlt = doc.ObjectTest.newAlternate();
       objAlt.test();
     });
 
@@ -51,7 +56,7 @@ void main() {
       // This test will fail until proc-macro support is implemented
       // Expected: Records should have documentation on fields
 
-      final record = RecordTest(test: 42);
+      final record = doc.RecordTest(test: 42);
       expect(record.test, equals(42));
     });
 
@@ -59,28 +64,24 @@ void main() {
       // This test will fail until proc-macro support is implemented
       // Expected: Functions should have proper documentation comments in generated Dart
 
-      test();
-      testMultiline();
-      testWithoutDocstring();
+      doc.test();
+      doc.testMultiline();
+      doc.testWithoutDocstring();
     });
 
     test(
       'proc-macro callback interface with docstring',
       () {
-        // This test will fail until callback interface support is implemented
-        // Expected: Callback interfaces should have documentation on methods
-
-        // final callback = CallbackTestImpl();
-        // callback.test();
+        final callback = CallbackTestImpl();
+        callback.test();
       },
-      skip: 'Requires callback interface implementation',
     );
 
     test('proc-macro long docstring', () {
       // This test will fail until proc-macro support is implemented
       // Expected: Long docstrings (>255 chars) should be properly handled
 
-      testLongDocstring();
+      doc.testLongDocstring();
     });
 
     test('documentation generation comparison', () {
@@ -88,16 +89,16 @@ void main() {
       // Expected: Both should generate equivalent documentation in Dart
 
       // Test basic functionality to ensure proc-macro definitions work
-      final enumValue = EnumTest.one;
-      expect(enumValue, equals(EnumTest.one));
+      final enumValue = doc.EnumTest.one;
+      expect(enumValue, equals(doc.EnumTest.one));
 
-      test();
-      testMultiline();
+      doc.test();
+      doc.testMultiline();
 
-      final obj = ObjectTest();
+      final obj = doc.ObjectTest();
       obj.test();
 
-      final record = RecordTest(test: 123);
+      final record = doc.RecordTest(test: 123);
       expect(record.test, equals(123));
     });
   });

--- a/fixtures/docstring-proc-macro/tests/mod.rs
+++ b/fixtures/docstring-proc-macro/tests/mod.rs
@@ -2,6 +2,6 @@
 mod tests {
     #[test]
     fn test_docstring_proc_macro() {
-        uniffi_dart::testing::run_test("docstring_proc_macro", None).unwrap();
+        uniffi_dart::testing::run_test("docstring-proc-macro", "src/api.udl", None).unwrap();
     }
 }

--- a/src/gen/callback_interface.rs
+++ b/src/gen/callback_interface.rs
@@ -51,6 +51,7 @@ impl Renderable for CallbackInterfaceCodeType {
             &callback.as_codetype().ffi_converter_name(),
             &callback.methods(),
             type_helper,
+            None,
         );
         let vtable_interface =
             generate_callback_vtable_interface(callback.name(), &callback.methods());
@@ -82,10 +83,30 @@ pub fn generate_callback_interface(
     ffi_converter_name: &str,
     methods: &[&Method],
     type_helper: &dyn TypeHelperRenderer,
+    rust_impl_name: Option<&str>,
 ) -> dart::Tokens {
     let cls_name = &DartCodeOracle::class_name(callback_name);
     let ffi_conv_name = &DartCodeOracle::class_name(ffi_converter_name);
     let init_fn_name = &format!("init{callback_name}VTable");
+    let lift_rust_impl = rust_impl_name
+        .map(|name| quote!(return $name._internal(handle);))
+        .unwrap_or_else(|| {
+            quote!(
+                throw UniffiInternalError(
+                    UniffiInternalError.unexpectedStaleHandle,
+                    "Rust-owned callback interface handle is not supported for $cls_name",
+                );
+            )
+        });
+    let lower_rust_impl = rust_impl_name
+        .map(|name| {
+            quote!(
+                if (value is $name) {
+                    return value.uniffiClonePointer();
+                }
+            )
+        })
+        .unwrap_or_else(|| quote!());
 
     // TODO: Use global deduplication to avoid generating duplicate async types
     // when multiple async callback interfaces are defined
@@ -137,10 +158,15 @@ pub fn generate_callback_interface(
             static bool _vtableInitialized = false;
 
             static $cls_name lift(Pointer<Void> handle) {
-                return _handleMap.get(handle.address);
+                final rawHandle = handle.address;
+                if ((rawHandle & 0x1) == 0) {
+                    $lift_rust_impl
+                }
+                return _handleMap.remove(rawHandle);
             }
 
             static Pointer<Void> lower($cls_name value) {
+                $lower_rust_impl
                 _ensureVTableInitialized();
                 final handle = _handleMap.insert(value);
                 return Pointer<Void>.fromAddress(handle);

--- a/src/gen/objects.rs
+++ b/src/gen/objects.rs
@@ -70,6 +70,7 @@ pub fn generate_object(obj: &Object, type_helper: &dyn TypeHelperRenderer) -> da
             &obj.as_codetype().ffi_converter_name(),
             &obj.methods(),
             type_helper,
+            Some(&format!("_{}Impl", DartCodeOracle::class_name(obj.name()))),
         );
         let vtable_interface = generate_callback_vtable_interface(obj.name(), &obj.methods());
         let functions = generate_callback_functions(obj.name(), &obj.methods(), type_helper);
@@ -87,8 +88,10 @@ pub fn generate_object(obj: &Object, type_helper: &dyn TypeHelperRenderer) -> da
             &obj.methods(),
             &ffi_module,
         );
+        let rust_impl = generate_callback_trait_rust_impl(obj, type_helper);
         return quote!(
             $interface
+            $rust_impl
             $vtable_interface
             $functions
             $vtable_init
@@ -316,6 +319,138 @@ pub fn generate_object(obj: &Object, type_helper: &dyn TypeHelperRenderer) -> da
         $error_handler_class
 
         $(stream_glue)
+    }
+}
+
+fn generate_callback_trait_rust_impl(
+    obj: &Object,
+    type_helper: &dyn TypeHelperRenderer,
+) -> dart::Tokens {
+    let cls_name = &DartCodeOracle::class_name(obj.name());
+    let impl_name = format!("_{cls_name}Impl");
+    let finalizer_field = format!("_{cls_name}ImplFinalizer");
+    let ffi_object_free_name = obj.ffi_object_free().name();
+    let ffi_object_clone_name = obj.ffi_object_clone().name();
+    let concrete_methods = obj
+        .methods()
+        .into_iter()
+        .map(|method| generate_callback_trait_rust_method(method, type_helper));
+
+    quote! {
+        final class $(&impl_name) implements $cls_name {
+            $(&impl_name)._internal(this._ptr) {
+                $(&finalizer_field).attach(this, _ptr, detach: this);
+            }
+
+            static final Finalizer<Pointer<Void>> $(&finalizer_field) =
+                Finalizer<Pointer<Void>>((ptr) {
+                    rustCall((status) => $ffi_object_free_name(ptr, status));
+                });
+
+            Pointer<Void> _ptr;
+
+            Pointer<Void> uniffiClonePointer() {
+                return rustCall((status) => $ffi_object_clone_name(_ptr, status));
+            }
+
+            void dispose() {
+                $(&finalizer_field).detach(this);
+                rustCall((status) => $ffi_object_free_name(_ptr, status));
+            }
+
+            $(for method in concrete_methods => $method)
+        }
+    }
+}
+
+fn generate_callback_trait_rust_method(
+    method: &Method,
+    type_helper: &dyn TypeHelperRenderer,
+) -> dart::Tokens {
+    let method_name = DartCodeOracle::fn_name(method.name());
+    let dart_args = method
+        .arguments()
+        .iter()
+        .map(|arg| {
+            let arg_type = arg.as_renderable().render_type(&arg.as_type(), type_helper);
+            let arg_name = DartCodeOracle::var_name(arg.name());
+            quote!($arg_type $arg_name)
+        })
+        .collect::<Vec<_>>();
+
+    let (ret, lifter) = if let Some(ret) = method.return_type() {
+        (
+            ret.as_renderable().render_type(ret, type_helper),
+            quote!($(ret.as_codetype().lift())),
+        )
+    } else {
+        (quote!(void), quote!((_) {}))
+    };
+
+    let error_handler = if let Some(error_type) = method.throws_type() {
+        let error_name = DartCodeOracle::class_name(error_type.name().unwrap_or("UnknownError"));
+        let handler_name = format!("{}ErrorHandler", error_name.to_lower_camel_case());
+        quote!($(handler_name))
+    } else {
+        quote!(null)
+    };
+
+    if method.is_async() {
+        let async_lifter = if let Some(ret_type) = method.return_type() {
+            match ret_type {
+                uniffi_bindgen::interface::Type::Object { .. } => {
+                    quote!((ptr) => $lifter(Pointer<Void>.fromAddress(ptr)))
+                }
+                _ => lifter.clone(),
+            }
+        } else {
+            lifter.clone()
+        };
+
+        quote! {
+            @override
+            Future<$ret> $method_name($(for a in &dart_args => $a,)) {
+                return uniffiRustCallAsync(
+                    () => $(method.ffi_func().name())(
+                        uniffiClonePointer(),
+                        $(for arg in &method.arguments() => $(DartCodeOracle::lower_arg_with_callback_handling(arg)),)
+                    ),
+                    $(DartCodeOracle::async_poll(method, type_helper.get_ci())),
+                    $(DartCodeOracle::async_complete(method, type_helper.get_ci())),
+                    $(DartCodeOracle::async_free(method, type_helper.get_ci())),
+                    $async_lifter,
+                    $error_handler,
+                );
+            }
+        }
+    } else if ret == quote!(void) {
+        quote! {
+            @override
+            $ret $method_name($(for a in &dart_args => $a,)) {
+                return rustCall((status) {
+                    $(method.ffi_func().name())(
+                        uniffiClonePointer(),
+                        $(for arg in &method.arguments() => $(DartCodeOracle::lower_arg_with_callback_handling(arg)),)
+                        status
+                    );
+                }, $error_handler);
+            }
+        }
+    } else {
+        quote! {
+            @override
+            $ret $method_name($(for a in &dart_args => $a,)) {
+                return rustCallWithLifter(
+                    (status) => $(method.ffi_func().name())(
+                        uniffiClonePointer(),
+                        $(for arg in &method.arguments() => $(DartCodeOracle::lower_arg_with_callback_handling(arg)),)
+                        status
+                    ),
+                    $lifter,
+                    $error_handler
+                );
+            }
+        }
     }
 }
 

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -511,11 +511,13 @@ impl Renderer<(FunctionDefinition, dart::Tokens)> for TypeHelpersRenderer<'_> {
                 return obj;
                 }
 
-                void remove(int handle) {
-                if (maybeRemove(handle) == null) {
+                T remove(int handle) {
+                final obj = maybeRemove(handle);
+                if (obj == null) {
                     throw UniffiInternalError(
                         UniffiInternalError.unexpectedStaleHandle, "Handle not found");
                 }
+                return obj;
                 }
 
                 T? maybeRemove(int handle) {


### PR DESCRIPTION
This fixes Dart bindings for `#[uniffi::export(with_foreign)]` callback traits when Rust returns an `Arc<dyn Trait>`.

UniFFI uses tagged callback/interface handles: odd values are foreign objects stored in the foreign-language handle map, while even values are Rust-owned object pointers. The Dart generator previously treated callback interface handles as handle-map entries only, which caused Rust-owned callback trait objects to fail with stale-handle errors.

This enables callback-heavy fixture coverage, adds regressions for the Payjoin-shaped `with_foreign` callback trait case, teaches callback interface lifting/lowering to distinguish tagged handles, and generates Dart proxy classes for Rust-backed callback traits so they can be called from Dart and passed back into Rust.