### PR TITLE
Test Nix dev shell setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake .

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,56 @@
+name: Nix
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+
+env:
+  NIX_CONFIG: experimental-features = nix-command flakes
+
+jobs:
+  flake-check:
+    name: Flake check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Use Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Run flake checks
+        run: nix flake check -L
+
+  dev-shell:
+    name: Dev shell (${{ matrix.shell }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shell:
+          - msrv
+          - stable
+          - nightly
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Use Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Verify shell tools
+        run: |
+          nix develop .#${{ matrix.shell }} -c bash -lc '
+            rustc --version
+            cargo --version
+            cargo nextest --version
+            dart --version
+          '

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 /target
+/result
+/result-*
 /uniffi-rs
 /Cargo.lock
 experiments/*
 og-fixtures/*
 .vscode/*
+.direnv/
 .aider*
 .dart_tool/*
 **/.dart_tool/*

--- a/README.md
+++ b/README.md
@@ -36,6 +36,53 @@ Run all fixture tests:
 cargo nextest run --all --nocapture
 ```
 
+### Nix Development Shells
+
+If Nix is available, the repository provides development shells with Rust,
+Dart, `cargo-nextest`, and formatting tools:
+
+Enable flakes and the new Nix CLI if they are not already enabled:
+
+```bash
+mkdir -p ~/.config/nix
+printf "experimental-features = nix-command flakes\n" >> ~/.config/nix/nix.conf
+```
+
+```bash
+nix develop
+nix develop .#msrv
+nix develop .#stable
+nix develop .#nightly
+```
+
+The default shell tracks the stable Rust toolchain. The `.#msrv` shell matches
+the declared Rust MSRV, currently 1.85.0.
+
+Run formatting through the flake:
+
+```bash
+nix fmt -- --ci
+```
+
+The flake formatter is currently scoped to Nix files only. Rust, Dart, and
+fixture formatting are left to the existing project commands to avoid unrelated
+format-only churn.
+
+Run the flake checks:
+
+```bash
+nix flake check
+```
+
+CI uses this as a Nix smoke check. The existing GitHub Actions workflows remain
+the authoritative full Rust, Dart, lint, and downstream test suite.
+
+Run the existing fixture test suite from a Nix shell:
+
+```bash
+nix develop .#msrv -c cargo nextest run --all
+```
+
 Run specific fixture tests:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -64,9 +64,8 @@ Run formatting through the flake:
 nix fmt -- --ci
 ```
 
-The flake formatter is currently scoped to Nix files only. Rust, Dart, and
-fixture formatting are left to the existing project commands to avoid unrelated
-format-only churn.
+The flake formatter covers Nix, Rust, and Dart files. Rust formatting uses the
+repository `rustfmt.toml`; Dart formatting runs with the latest language version.
 
 Run the flake checks:
 

--- a/fixtures/benchmarks/src/lib.rs
+++ b/fixtures/benchmarks/src/lib.rs
@@ -38,24 +38,15 @@ pub fn test_no_args_void_return() {
 pub fn run_benchmarks(language: String, cb: Box<dyn TestCallbackInterface>) {
     println!("Running benchmarks for {language}");
 
-    let test_data = TestData {
-        foo: "SomeStringData".to_string(),
-        bar: "SomeMoreStringData".to_string(),
-    };
+    let test_data =
+        TestData { foo: "SomeStringData".to_string(), bar: "SomeMoreStringData".to_string() };
 
     // Simple timing-based benchmarks (not using Criterion for now to avoid complexity)
 
     // Test function calls
     let start = Instant::now();
     for _ in 0..1000 {
-        test_function(
-            10,
-            100,
-            TestData {
-                foo: test_data.foo.clone(),
-                bar: test_data.bar.clone(),
-            },
-        );
+        test_function(10, 100, TestData { foo: test_data.foo.clone(), bar: test_data.bar.clone() });
     }
     let function_time = start.elapsed();
     println!("{language}-functions-basic: {:?}", function_time);
@@ -66,10 +57,7 @@ pub fn run_benchmarks(language: String, cb: Box<dyn TestCallbackInterface>) {
         test_void_return(
             10,
             100,
-            TestData {
-                foo: test_data.foo.clone(),
-                bar: test_data.bar.clone(),
-            },
+            TestData { foo: test_data.foo.clone(), bar: test_data.bar.clone() },
         );
     }
     let void_time = start.elapsed();
@@ -81,22 +69,12 @@ pub fn run_benchmarks(language: String, cb: Box<dyn TestCallbackInterface>) {
         test_no_args_void_return();
     }
     let no_args_time = start.elapsed();
-    println!(
-        "{language}-functions-no-args-void-return: {:?}",
-        no_args_time
-    );
+    println!("{language}-functions-no-args-void-return: {:?}", no_args_time);
 
     // Test callbacks
     let start = Instant::now();
     for _ in 0..1000 {
-        cb.method(
-            10,
-            100,
-            TestData {
-                foo: test_data.foo.clone(),
-                bar: test_data.bar.clone(),
-            },
-        );
+        cb.method(10, 100, TestData { foo: test_data.foo.clone(), bar: test_data.bar.clone() });
     }
     let callback_time = start.elapsed();
     println!("{language}-callbacks-basic: {:?}", callback_time);
@@ -107,10 +85,7 @@ pub fn run_benchmarks(language: String, cb: Box<dyn TestCallbackInterface>) {
         cb.method_with_void_return(
             10,
             100,
-            TestData {
-                foo: test_data.foo.clone(),
-                bar: test_data.bar.clone(),
-            },
+            TestData { foo: test_data.foo.clone(), bar: test_data.bar.clone() },
         );
     }
     let callback_void_time = start.elapsed();
@@ -122,10 +97,7 @@ pub fn run_benchmarks(language: String, cb: Box<dyn TestCallbackInterface>) {
         cb.method_with_no_args_and_void_return();
     }
     let callback_no_args_time = start.elapsed();
-    println!(
-        "{language}-callbacks-no-args-void-return: {:?}",
-        callback_no_args_time
-    );
+    println!("{language}-callbacks-no-args-void-return: {:?}", callback_no_args_time);
 
     println!("Benchmarks complete for {language}!");
 }

--- a/fixtures/callbacks/src/lib.rs
+++ b/fixtures/callbacks/src/lib.rs
@@ -170,17 +170,11 @@ impl InMemoryEventPersister {
 
 impl JsonEventPersister for InMemoryEventPersister {
     fn save(&self, event: String) {
-        self.events
-            .lock()
-            .expect("event persister lock poisoned")
-            .push(event);
+        self.events.lock().expect("event persister lock poisoned").push(event);
     }
 
     fn load(&self) -> Vec<String> {
-        self.events
-            .lock()
-            .expect("event persister lock poisoned")
-            .clone()
+        self.events.lock().expect("event persister lock poisoned").clone()
     }
 
     fn close(&self) {}

--- a/fixtures/custom_types/src/lib.rs
+++ b/fixtures/custom_types/src/lib.rs
@@ -24,10 +24,7 @@ pub fn get_zen_engine_response() -> ZenEngineResponse {
         result: JsonBuffer(vec![1, 2, 3]),
         trace: Some(HashMap::from([(
             "primary".to_string(),
-            ZenEngineTrace {
-                id: "primary".to_string(),
-                value: JsonBuffer(vec![4, 5, 6]),
-            },
+            ZenEngineTrace { id: "primary".to_string(), value: JsonBuffer(vec![4, 5, 6]) },
         )])),
     }
 }

--- a/fixtures/dart_async/src/lib.rs
+++ b/fixtures/dart_async/src/lib.rs
@@ -1,11 +1,9 @@
-use std::{
-    future::Future,
-    pin::Pin,
-    sync::{Arc, Mutex, MutexGuard},
-    task::{Context, Poll, Waker},
-    thread,
-    time::Duration,
-};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::task::{Context, Poll, Waker};
+use std::thread;
+use std::time::Duration;
 
 use futures::future::{AbortHandle, Abortable, Aborted};
 use once_cell::sync::Lazy;
@@ -36,10 +34,7 @@ impl Future for TimerFuture {
 
 impl TimerFuture {
     pub fn new(duration: Duration) -> Self {
-        let shared_state = Arc::new(Mutex::new(SharedState {
-            completed: false,
-            waker: None,
-        }));
+        let shared_state = Arc::new(Mutex::new(SharedState { completed: false, waker: None }));
 
         let thread_shared_state = shared_state.clone();
         // Let's mimic an event coming from somewhere else, like the system.
@@ -77,10 +72,7 @@ impl Future for BrokenTimerFuture {
 
 impl BrokenTimerFuture {
     pub fn new(duration: Duration, fail_after: Duration) -> Self {
-        let shared_state = Arc::new(Mutex::new(SharedState {
-            completed: false,
-            waker: None,
-        }));
+        let shared_state = Arc::new(Mutex::new(SharedState { completed: false, waker: None }));
 
         let thread_shared_state = shared_state.clone();
         // Let's mimic an event coming from somewhere else, like the system.
@@ -196,16 +188,8 @@ pub async fn new_my_record(a: String, b: u32) -> MyRecord {
 #[uniffi::export]
 pub fn list_async_items() -> Vec<AsyncItem> {
     vec![
-        AsyncItem {
-            id: 1,
-            state: AsyncItemState::Ready { timestamp_ms: 1111 },
-        },
-        AsyncItem {
-            id: 2,
-            state: AsyncItemState::Pending {
-                reason: "syncing".to_string(),
-            },
-        },
+        AsyncItem { id: 1, state: AsyncItemState::Ready { timestamp_ms: 1111 } },
+        AsyncItem { id: 2, state: AsyncItemState::Pending { reason: "syncing".to_string() } },
     ]
 }
 
@@ -336,19 +320,14 @@ pub enum AsyncError {
 
 #[uniffi::export(async_runtime = "tokio")]
 pub async fn use_shared_resource(options: SharedResourceOptions) -> Result<(), AsyncError> {
-    use tokio::{
-        sync::Mutex,
-        time::{sleep, timeout},
-    };
+    use tokio::sync::Mutex;
+    use tokio::time::{sleep, timeout};
 
     static MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
-    let _guard = timeout(
-        Duration::from_millis(options.timeout_ms.into()),
-        MUTEX.lock(),
-    )
-    .await
-    .map_err(|_| AsyncError::Timeout)?;
+    let _guard = timeout(Duration::from_millis(options.timeout_ms.into()), MUTEX.lock())
+        .await
+        .map_err(|_| AsyncError::Timeout)?;
 
     sleep(Duration::from_millis(options.release_after_ms.into())).await;
     Ok(())

--- a/fixtures/dispose/src/lib.rs
+++ b/fixtures/dispose/src/lib.rs
@@ -1,8 +1,8 @@
-use uniffi;
-
-use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+
+use once_cell::sync::Lazy;
+use uniffi;
 
 static LIVE_COUNT: Lazy<RwLock<i32>> = Lazy::new(|| RwLock::new(0));
 
@@ -56,16 +56,12 @@ fn get_resource() -> Arc<Resource> {
 
 #[uniffi::export]
 fn get_resource_journal_list() -> ResourceJournalList {
-    ResourceJournalList {
-        resources: vec![get_resource(), get_resource()],
-    }
+    ResourceJournalList { resources: vec![get_resource(), get_resource()] }
 }
 
 #[uniffi::export]
 fn get_resource_journal_map() -> ResourceJournalMap {
-    ResourceJournalMap {
-        resources: HashMap::from([(1, get_resource()), (2, get_resource())]),
-    }
+    ResourceJournalMap { resources: HashMap::from([(1, get_resource()), (2, get_resource())]) }
 }
 
 #[uniffi::export]
@@ -77,9 +73,7 @@ fn get_resource_journal_map_list() -> ResourceJournalMapList {
 
 #[uniffi::export]
 fn get_maybe_resource_journal() -> MaybeResourceJournal {
-    MaybeResourceJournal::Some {
-        resource: get_resource_journal_list(),
-    }
+    MaybeResourceJournal::Some { resource: get_resource_journal_list() }
 }
 
 uniffi::include_scaffolding!("api");

--- a/fixtures/duration_type_test/src/lib.rs
+++ b/fixtures/duration_type_test/src/lib.rs
@@ -1,4 +1,5 @@
 use core::time::Duration;
+
 use uniffi;
 
 #[uniffi::export]

--- a/fixtures/enum-types/src/lib.rs
+++ b/fixtures/enum-types/src/lib.rs
@@ -44,9 +44,7 @@ pub struct AnimalRecord {
 
 impl AnimalRecord {
     pub fn new(name: &str) -> Self {
-        Self {
-            name: name.to_string(),
-        }
+        Self { name: name.to_string() }
     }
 }
 
@@ -58,9 +56,7 @@ pub struct AnimalObject {
 
 impl AnimalObject {
     pub fn new(name: &str) -> Self {
-        Self {
-            value: AnimalRecord::new(name),
-        }
+        Self { value: AnimalRecord::new(name) }
     }
 }
 

--- a/fixtures/error_types/src/lib.rs
+++ b/fixtures/error_types/src/lib.rs
@@ -26,26 +26,18 @@ impl From<anyhow::Error> for ErrorInterface {
 // Test an interface as the error type
 fn oops() -> Result<(), Arc<ErrorInterface>> {
     // must do explicit conversion to convert anyhow::Error into ErrorInterface
-    Err(Arc::new(
-        anyhow::Error::msg("oops")
-            .context("because uniffi told me so")
-            .into(),
-    ))
+    Err(Arc::new(anyhow::Error::msg("oops").context("because uniffi told me so").into()))
 }
 
 // Like `oops`, but let UniFFI handle wrapping the interface with an arc
 fn oops_nowrap() -> Result<(), ErrorInterface> {
     // must do explicit conversion to convert anyhow::Error into ErrorInterface
-    Err(anyhow::Error::msg("oops")
-        .context("because uniffi told me so")
-        .into())
+    Err(anyhow::Error::msg("oops").context("because uniffi told me so").into())
 }
 
 #[uniffi::export]
 fn toops() -> Result<(), Arc<dyn ErrorTrait>> {
-    Err(Arc::new(ErrorTraitImpl {
-        m: "trait-oops".to_string(),
-    }))
+    Err(Arc::new(ErrorTraitImpl { m: "trait-oops".to_string() }))
 }
 
 #[uniffi::export]
@@ -99,11 +91,7 @@ impl TestInterface {
     }
 
     fn oops(&self) -> Result<(), Arc<ErrorInterface>> {
-        Err(Arc::new(
-            anyhow::Error::msg("oops")
-                .context("because the interface told me so")
-                .into(),
-        ))
+        Err(Arc::new(anyhow::Error::msg("oops").context("because the interface told me so").into()))
     }
 }
 
@@ -193,25 +181,17 @@ fn oops_enum(i: u16) -> Result<(), Error> {
     if i == 0 {
         Err(Error::Oops)
     } else if i == 1 {
-        Err(Error::Value {
-            value: "value".to_string(),
-        })
+        Err(Error::Value { value: "value".to_string() })
     } else if i == 2 {
         Err(Error::IntValue { value: i })
     } else if i == 3 {
-        Err(Error::FlatInnerError {
-            error: FlatInner::CaseA("inner".to_string()),
-        })
+        Err(Error::FlatInnerError { error: FlatInner::CaseA("inner".to_string()) })
     } else if i == 4 {
         Err(Error::FlatInnerError {
-            error: FlatInner::CaseB(NonUniffiType {
-                v: "value".to_string(),
-            }),
+            error: FlatInner::CaseB(NonUniffiType { v: "value".to_string() }),
         })
     } else if i == 5 {
-        Err(Error::InnerError {
-            error: Inner::CaseA("inner".to_string()),
-        })
+        Err(Error::InnerError { error: Inner::CaseA("inner".to_string()) })
     } else {
         panic!("unknown variant {i}")
     }

--- a/fixtures/hello_world/src/lib.rs
+++ b/fixtures/hello_world/src/lib.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+
 use uniffi;
 
 #[derive(uniffi::Record, Clone)]
@@ -9,10 +10,7 @@ pub struct WorldState {
 
 impl WorldState {
     fn new(name: Option<String>) -> WorldState {
-        WorldState {
-            inhabitants: 0,
-            name,
-        }
+        WorldState { inhabitants: 0, name }
     }
 }
 

--- a/fixtures/keywords/src/lib.rs
+++ b/fixtures/keywords/src/lib.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 pub fn r#if(_async: u8) {}
 

--- a/fixtures/large-error/src/lib.rs
+++ b/fixtures/large-error/src/lib.rs
@@ -59,21 +59,11 @@ pub enum LargeError {
     Case31 { arg1: ErrorPayload },
 
     #[error("Important debug description of what went wrong, arg1: '{arg1}', arg2: '{arg2}', arg3: '{arg3}', arg4: '{arg4}'")]
-    Case40 {
-        arg1: ErrorPayload,
-        arg2: ErrorPayload,
-        arg3: ErrorPayload,
-        arg4: ErrorPayload,
-    },
+    Case40 { arg1: ErrorPayload, arg2: ErrorPayload, arg3: ErrorPayload, arg4: ErrorPayload },
 
     // ... (abbreviated from 100 cases to show pattern)
     #[error("Important debug description of what went wrong, arg1: '{arg1}', arg2: '{arg2}', arg3: '{arg3}', arg4: '{arg4}'")]
-    Case100 {
-        arg1: ErrorPayload,
-        arg2: ErrorPayload,
-        arg3: ErrorPayload,
-        arg4: ErrorPayload,
-    },
+    Case100 { arg1: ErrorPayload, arg2: ErrorPayload, arg3: ErrorPayload, arg4: ErrorPayload },
 }
 
 impl LargeError {

--- a/fixtures/large_enum/src/lib.rs
+++ b/fixtures/large_enum/src/lib.rs
@@ -1,5 +1,4 @@
-use uniffi;
-use uniffi::{Enum, Record};
+use uniffi::{self, Enum, Record};
 
 #[uniffi::export]
 pub fn new_flat_one() -> FlatEnum {
@@ -93,9 +92,7 @@ pub fn new_bool_value(value: bool) -> Value {
 // Holding off till refactor
 #[uniffi::export]
 pub fn new_public_key_value_without_argument() -> Value {
-    Value::PublicKey {
-        value: vec![3, 4, 4, 5, 4, 24434398, 4],
-    }
+    Value::PublicKey { value: vec![3, 4, 4, 5, 4, 24434398, 4] }
 }
 
 #[uniffi::export]

--- a/fixtures/proc-macro-no-implicit-prelude/src/lib.rs
+++ b/fixtures/proc-macro-no-implicit-prelude/src/lib.rs
@@ -4,9 +4,9 @@
 #![no_implicit_prelude]
 
 // Let's not have the macros care about derive being shadowed in the macro namespace for now..
-use ::std::prelude::rust_2021::derive;
 // Required for now because `static-assertions` (used internally) macros assume it to be in scope.
 use ::std::marker::Sized;
+use ::std::prelude::rust_2021::derive;
 
 mod callback_interface;
 
@@ -164,23 +164,18 @@ fn take_record_with_bytes(rwb: RecordWithBytes) -> ::std::vec::Vec<u8> {
 
 #[::uniffi::export]
 pub fn call_callback_interface(cb: ::std::sync::Arc<dyn TestCallbackInterface>) {
-    use ::std::{assert_eq, matches, option::Option::*, result::Result::*, string::ToString, vec};
+    use ::std::option::Option::*;
+    use ::std::result::Result::*;
+    use ::std::string::ToString;
+    use ::std::{assert_eq, matches, vec};
 
     cb.do_nothing();
     assert_eq!(cb.add(1, 1), 2);
     assert_eq!(cb.optional(Some(1)), 1);
     assert_eq!(cb.optional(None), 0);
-    assert_eq!(
-        cb.with_bytes(RecordWithBytes {
-            some_bytes: vec![9, 8, 7],
-        }),
-        vec![9, 8, 7]
-    );
+    assert_eq!(cb.with_bytes(RecordWithBytes { some_bytes: vec![9, 8, 7] }), vec![9, 8, 7]);
     assert_eq!(Ok(10), cb.try_parse_int("10".to_string()));
-    assert_eq!(
-        Err(BasicError::InvalidInput),
-        cb.try_parse_int("ten".to_string())
-    );
+    assert_eq!(Err(BasicError::InvalidInput), cb.try_parse_int("ten".to_string()));
     assert!(matches!(
         cb.try_parse_int("force-unexpected-error".to_string()),
         Err(BasicError::UnexpectedError { .. }),
@@ -198,16 +193,12 @@ pub struct Zero {
 #[::uniffi::export]
 fn make_zero() -> Zero {
     use ::std::borrow::ToOwned;
-    Zero {
-        inner: "ZERO".to_owned(),
-    }
+    Zero { inner: "ZERO".to_owned() }
 }
 
 #[::uniffi::export]
 fn make_record_with_bytes() -> RecordWithBytes {
-    RecordWithBytes {
-        some_bytes: ::std::vec![0, 1, 2, 3, 4],
-    }
+    RecordWithBytes { some_bytes: ::std::vec![0, 1, 2, 3, 4] }
 }
 
 #[derive(::uniffi::Enum)]

--- a/fixtures/proc-macro/src/callback_interface.rs
+++ b/fixtures/proc-macro/src/callback_interface.rs
@@ -1,5 +1,6 @@
-use crate::{BasicError, Object, RecordWithBytes};
 use std::sync::Arc;
+
+use crate::{BasicError, Object, RecordWithBytes};
 
 #[uniffi::export(with_foreign)]
 pub trait TestCallbackInterface: Send + Sync {

--- a/fixtures/proc-macro/src/lib.rs
+++ b/fixtures/proc-macro/src/lib.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 mod callback_interface;
 pub use callback_interface::{OtherCallbackInterface, TestCallbackInterface};
@@ -122,9 +123,7 @@ pub struct Zero {
 
 #[uniffi::export]
 fn make_zero() -> Zero {
-    Zero {
-        inner: String::from("ZERO"),
-    }
+    Zero { inner: String::from("ZERO") }
 }
 
 // UDL functions that reference proc-macro types

--- a/fixtures/simple-fns/src/lib.rs
+++ b/fixtures/simple-fns/src/lib.rs
@@ -50,9 +50,7 @@ pub struct MyHashSet {
 
 impl MyHashSet {
     pub fn new() -> Self {
-        Self {
-            inner: Mutex::new(HashSet::new()),
-        }
+        Self { inner: Mutex::new(HashSet::new()) }
     }
 
     pub fn add(&self, value: String) {

--- a/fixtures/simple-iface/src/lib.rs
+++ b/fixtures/simple-iface/src/lib.rs
@@ -41,9 +41,7 @@ impl PayloadError {
 
 impl ProtocolError {
     pub fn new(message: String) -> Self {
-        Self {
-            payload_error: Arc::new(PayloadError::new(message)),
-        }
+        Self { payload_error: Arc::new(PayloadError::new(message)) }
     }
 
     pub fn payload_error(self: Arc<Self>) -> Option<Arc<PayloadError>> {

--- a/fixtures/streams_ext/src/lib.rs
+++ b/fixtures/streams_ext/src/lib.rs
@@ -1,7 +1,9 @@
+use std::pin::Pin;
+use std::time::Duration;
+
 use async_stream::stream;
 use futures::stream::{self, Stream, StreamExt};
 use smol::Timer;
-use std::{pin::Pin, time::Duration};
 
 // // Define custom error enums
 // #[derive(Debug, thiserror::Error)]
@@ -55,9 +57,7 @@ pub fn async_timer_stream() -> Pin<Box<dyn Stream<Item = u64> + Send>> {
 #[uniffi_dart::export_stream(String)]
 pub fn combined_streams() -> impl Stream<Item = String> + Send {
     let stream1 = count_stream().take(5).map(|n| format!("Count: {}", n));
-    let stream3 = fibonacci_stream()
-        .take(5)
-        .map(|n| format!("Fibonacci: {}", n));
+    let stream3 = fibonacci_stream().take(5).map(|n| format!("Fibonacci: {}", n));
 
     stream::select(stream1, stream3)
 }
@@ -122,9 +122,10 @@ pub fn combined_streams() -> impl Stream<Item = String> + Send {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use futures::stream::StreamExt;
     use smol::block_on;
+
+    use super::*;
 
     #[test]
     fn test_simple_stream() {

--- a/fixtures/time-types/src/lib.rs
+++ b/fixtures/time-types/src/lib.rs
@@ -29,19 +29,15 @@ fn to_string_timestamp(a: SystemTime) -> String {
 }
 
 fn get_pre_epoch_timestamp() -> SystemTime {
-    std::time::SystemTime::UNIX_EPOCH
-        .checked_sub(std::time::Duration::new(1, 1_000_000))
-        .unwrap()
+    std::time::SystemTime::UNIX_EPOCH.checked_sub(std::time::Duration::new(1, 1_000_000)).unwrap()
 }
 
 fn add(a: SystemTime, b: Duration) -> Result<SystemTime> {
-    a.checked_add(b)
-        .ok_or(ChronologicalError::TimeOverflow { a, b })
+    a.checked_add(b).ok_or(ChronologicalError::TimeOverflow { a, b })
 }
 
 fn diff(a: SystemTime, b: SystemTime) -> Result<Duration> {
-    a.duration_since(b)
-        .map_err(|_| ChronologicalError::TimeDiffError { a, b })
+    a.duration_since(b).map_err(|_| ChronologicalError::TimeDiffError { a, b })
 }
 
 fn now() -> SystemTime {
@@ -64,8 +60,7 @@ fn set_seconds_before_unix_epoch(seconds: u64) -> Result<SystemTime> {
     let a = SystemTime::UNIX_EPOCH;
     let b = Duration::from_secs(seconds);
 
-    a.checked_sub(b)
-        .ok_or(ChronologicalError::TimeOverflow { a, b })
+    a.checked_sub(b).ok_or(ChronologicalError::TimeOverflow { a, b })
 }
 
 type Result<T, E = ChronologicalError> = std::result::Result<T, E>;

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,103 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776434932,
+        "narHash": "sha256-gyqXNMgk3sh+ogY5svd2eNLJ6oEwzbAeaoBrrxD0lKk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c7f47036d3df2add644c46d712d14262b7d86c0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776654897,
+        "narHash": "sha256-Vqi4AiJVCcBGn/RmBtRCgyH5rCxqm/w0xV9diJWF1Ic=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "25d75be8139815a53560745fa060909777495105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,99 @@
+{
+  description = "uniffi-dart";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      treefmt-nix,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        msrvVersion = "1.85.0";
+
+        rustExtensions = [
+          "clippy"
+          "rust-src"
+          "rustfmt"
+        ];
+
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            rust-overlay.overlays.default
+            (_final: prev: {
+              rustToolchains = {
+                msrv = prev.rust-bin.stable.${msrvVersion}.default.override {
+                  extensions = rustExtensions;
+                };
+                stable = prev.rust-bin.stable.latest.default.override {
+                  extensions = rustExtensions;
+                };
+                nightly = prev.rust-bin.nightly.latest.default.override {
+                  extensions = rustExtensions;
+                };
+              };
+            })
+          ];
+        };
+
+        rustToolchains = pkgs.rustToolchains;
+
+        treefmtEval = treefmt-nix.lib.evalModule pkgs ./treefmt.nix;
+
+        devPackages = with pkgs; [
+          cargo-edit
+          cargo-nextest
+          cargo-watch
+          codespell
+          dart
+          git
+          pkg-config
+          rust-analyzer
+          taplo
+        ];
+
+        shellHook = ''
+          export CARGO_WORKSPACE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+        '';
+
+        devShells = builtins.mapAttrs (
+          _name: rustToolchain:
+          pkgs.mkShell {
+            packages = [
+              rustToolchain
+            ]
+            ++ devPackages;
+            inherit shellHook;
+          }
+        ) rustToolchains;
+      in
+      {
+        devShells = devShells // {
+          default = devShells.stable;
+        };
+
+        formatter = treefmtEval.config.build.wrapper;
+
+        checks = {
+          formatting = treefmtEval.config.build.check self;
+        };
+      }
+    );
+}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,23 @@
+## Based on https://github.com/payjoin/rust-payjoin/blob/master/rustfmt.toml
+##
+## Keep this to stable rustfmt options because this repository's lint matrix runs
+## `cargo fmt --all -- --check` on MSRV, stable, and nightly Rust.
+
+hard_tabs = false
+tab_spaces = 4
+newline_style = "Auto"
+
+max_width = 100
+use_small_heuristics = "Max"
+
+reorder_imports = true
+reorder_modules = true
+remove_nested_parens = true
+fn_params_layout = "Tall"
+match_block_trailing_comma = false
+edition = "2021"
+merge_derives = true
+use_try_shorthand = false
+use_field_init_shorthand = false
+force_explicit_abi = true
+disable_all_formatting = false

--- a/src/build.rs
+++ b/src/build.rs
@@ -1,6 +1,7 @@
+use std::env;
+
 use anyhow::{Context, Result};
 use camino::Utf8Path;
-use std::env;
 
 pub fn generate_scaffolding(udl_file: &Utf8Path) -> Result<()> {
     uniffi_build::generate_scaffolding(udl_file)?;

--- a/src/gen/callback_interface.rs
+++ b/src/gen/callback_interface.rs
@@ -1,15 +1,11 @@
-use crate::gen::CodeType;
 use genco::prelude::*;
 use heck::ToUpperCamelCase;
-use uniffi_bindgen::interface::Type;
-use uniffi_bindgen::interface::{
-    ffi::{FfiStruct, FfiType},
-    AsType, Method,
-};
+use uniffi_bindgen::interface::ffi::{FfiStruct, FfiType};
+use uniffi_bindgen::interface::{AsType, Method, Type};
 
 use crate::gen::oracle::{AsCodeType, DartCodeOracle};
-use crate::gen::render::AsRenderable;
-use crate::gen::render::{Renderable, TypeHelperRenderer};
+use crate::gen::render::{AsRenderable, Renderable, TypeHelperRenderer};
+use crate::gen::CodeType;
 
 #[derive(Debug)]
 pub struct CallbackInterfaceCodeType {
@@ -40,10 +36,7 @@ impl CodeType for CallbackInterfaceCodeType {
 impl Renderable for CallbackInterfaceCodeType {
     fn render_type_helper(&self, type_helper: &dyn TypeHelperRenderer) -> dart::Tokens {
         type_helper.include_once_check(&self.canonical_name(), &self.self_type);
-        let callback = type_helper
-            .get_ci()
-            .get_callback_interface_definition(&self.name)
-            .unwrap();
+        let callback = type_helper.get_ci().get_callback_interface_definition(&self.name).unwrap();
 
         // Generate all necessary components for the callback interface
         let interface = generate_callback_interface(
@@ -88,9 +81,8 @@ pub fn generate_callback_interface(
     let cls_name = &DartCodeOracle::class_name(callback_name);
     let ffi_conv_name = &DartCodeOracle::class_name(ffi_converter_name);
     let init_fn_name = &format!("init{callback_name}VTable");
-    let lift_rust_impl = rust_impl_name
-        .map(|name| quote!(return $name._internal(handle);))
-        .unwrap_or_else(|| {
+    let lift_rust_impl =
+        rust_impl_name.map(|name| quote!(return $name._internal(handle);)).unwrap_or_else(|| {
             quote!(
                 throw UniffiInternalError(
                     UniffiInternalError.unexpectedStaleHandle,
@@ -117,10 +109,8 @@ pub fn generate_callback_interface(
             let struct_name = struct_def.name().to_string();
 
             if !type_helper.include_once_by_name(&struct_name) {
-                async_struct_defs.push(generate_foreign_future_struct_definition(
-                    &struct_def,
-                    type_helper,
-                ));
+                async_struct_defs
+                    .push(generate_foreign_future_struct_definition(&struct_def, type_helper));
             }
 
             let completion_name = foreign_future_completion_name(method);
@@ -529,9 +519,7 @@ fn callback_error_handling(
     status: dart::Tokens,
 ) -> dart::Tokens {
     if let Some(error_type) = throws_type {
-        let error_type_label = error_type
-            .as_renderable()
-            .render_type(error_type, type_helper);
+        let error_type_label = error_type.as_renderable().render_type(error_type, type_helper);
         let error_lower = error_type.as_codetype().ffi_converter_name();
         quote! {
             if (e is $error_type_label) {

--- a/src/gen/code_type.rs
+++ b/src/gen/code_type.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+
 use uniffi_bindgen::pipeline::general::nodes::Literal;
 
 /// A trait tor the implementation.

--- a/src/gen/compounds.rs
+++ b/src/gen/compounds.rs
@@ -1,4 +1,3 @@
-use crate::gen::CodeType;
 use genco::lang::dart;
 use genco::prelude::*;
 use paste::paste;
@@ -6,6 +5,7 @@ use uniffi_bindgen::interface::Type;
 
 use super::oracle::{AsCodeType, DartCodeOracle};
 use crate::gen::render::{AsRenderable, Renderable, TypeHelperRenderer};
+use crate::gen::CodeType;
 
 macro_rules! impl_code_type_for_compound {
      ($T:ty, $type_label_pattern:literal, $canonical_name_pattern: literal) => {
@@ -254,11 +254,7 @@ pub struct MapCodeType {
 
 impl MapCodeType {
     pub fn new(self_type: Type, key: Type, value: Type) -> Self {
-        Self {
-            self_type,
-            key,
-            value,
-        }
+        Self { self_type, key, value }
     }
 
     fn key(&self) -> &Type {

--- a/src/gen/custom.rs
+++ b/src/gen/custom.rs
@@ -1,9 +1,9 @@
+use genco::prelude::*;
+use uniffi_bindgen::interface::{AsType, Type};
+
 use super::oracle::{AsCodeType, DartCodeOracle};
 use super::render::{Renderable, TypeHelperRenderer};
 use super::CodeType;
-use genco::prelude::*;
-use uniffi_bindgen::interface::AsType;
-use uniffi_bindgen::interface::Type;
 
 #[derive(Debug)]
 pub struct CustomCodeType {
@@ -14,11 +14,7 @@ pub struct CustomCodeType {
 
 impl CustomCodeType {
     pub fn new(name: String, module_path: String, builtin: Box<Type>) -> Self {
-        CustomCodeType {
-            name,
-            module_path,
-            builtin,
-        }
+        CustomCodeType { name, module_path, builtin }
     }
 }
 

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -1,4 +1,3 @@
-use crate::gen::CodeType;
 use genco::prelude::*;
 use heck::ToLowerCamelCase;
 use uniffi_bindgen::interface::{AsType, Enum, Field, Type};
@@ -6,6 +5,7 @@ use uniffi_bindgen::pipeline::general::nodes::Literal;
 
 use super::oracle::{AsCodeType, DartCodeOracle};
 use super::render::{AsRenderable, Renderable, TypeHelperRenderer};
+use crate::gen::CodeType;
 
 #[derive(Debug)]
 pub struct EnumCodeType {
@@ -29,11 +29,7 @@ impl CodeType for EnumCodeType {
 
     fn literal(&self, literal: &Literal) -> String {
         if let Literal::Enum(v, _) = literal {
-            format!(
-                "{}{}",
-                self.type_label(),
-                DartCodeOracle::enum_variant_name(v)
-            )
+            format!("{}{}", self.type_label(), DartCodeOracle::enum_variant_name(v))
         } else {
             unreachable!();
         }
@@ -62,11 +58,8 @@ pub fn generate_enum(obj: &Enum, type_helper: &dyn TypeHelperRenderer) -> dart::
     let ffi_converter_name = &obj.as_codetype().ffi_converter_name();
     if obj.is_flat() {
         let is_error_enum = type_helper.get_ci().is_name_used_as_error(obj.name());
-        let implements_exception = if is_error_enum {
-            quote!( implements Exception)
-        } else {
-            quote!()
-        };
+        let implements_exception =
+            if is_error_enum { quote!( implements Exception) } else { quote!() };
 
         // For flat error enums, generate an error handler
         let error_handler_class = if is_error_enum {
@@ -152,11 +145,7 @@ pub fn generate_enum(obj: &Enum, type_helper: &dyn TypeHelperRenderer) -> dart::
                 .replace("Error", "Exception")
         }
         fn field_ffi_converter_name(field: &Field) -> String {
-            field
-                .as_type()
-                .as_codetype()
-                .ffi_converter_name()
-                .replace("Error", "Exception")
+            field.as_type().as_codetype().ffi_converter_name().replace("Error", "Exception")
         }
         fn is_flat_enum(field: &Field, type_helper: &dyn TypeHelperRenderer) -> bool {
             if let Type::Enum { name, .. } = &field.as_type() {
@@ -171,11 +160,8 @@ pub fn generate_enum(obj: &Enum, type_helper: &dyn TypeHelperRenderer) -> dart::
             for f in variant_obj.fields() {
                 type_helper.include_once_check(&f.as_codetype().canonical_name(), &f.as_type());
             }
-            let variant_dart_cls_name = &format!(
-                "{}{}",
-                DartCodeOracle::class_name(variant_obj.name()),
-                dart_cls_name
-            );
+            let variant_dart_cls_name =
+                &format!("{}{}", DartCodeOracle::class_name(variant_obj.name()), dart_cls_name);
 
             // Prepare constructor parameters
             let constructor_params = variant_obj
@@ -321,11 +307,8 @@ pub fn generate_enum(obj: &Enum, type_helper: &dyn TypeHelperRenderer) -> dart::
         }
 
         let is_error_enum = type_helper.get_ci().is_name_used_as_error(obj.name());
-        let implements_exception = if is_error_enum {
-            quote!( implements Exception)
-        } else {
-            quote!()
-        };
+        let implements_exception =
+            if is_error_enum { quote!( implements Exception) } else { quote!() };
 
         // For error enums, also generate an error handler
         let error_handler_class = if is_error_enum {

--- a/src/gen/functions.rs
+++ b/src/gen/functions.rs
@@ -2,11 +2,10 @@ use genco::prelude::*;
 use heck::ToLowerCamelCase;
 use uniffi_bindgen::interface::{AsType, Function};
 
-use crate::gen::oracle::DartCodeOracle;
-use crate::gen::render::AsRenderable;
-
 use super::oracle::AsCodeType;
 use super::render::TypeHelperRenderer;
+use crate::gen::oracle::DartCodeOracle;
+use crate::gen::render::AsRenderable;
 
 pub fn generate_function(func: &Function, type_helper: &dyn TypeHelperRenderer) -> dart::Tokens {
     let args = if func.arguments().is_empty() {
@@ -16,10 +15,7 @@ pub fn generate_function(func: &Function, type_helper: &dyn TypeHelperRenderer) 
     };
 
     let (ret, lifter) = if let Some(ret) = func.return_type() {
-        (
-            ret.as_renderable().render_type(ret, type_helper),
-            quote!($(ret.as_codetype().lift())),
-        )
+        (ret.as_renderable().render_type(ret, type_helper), quote!($(ret.as_codetype().lift())))
     } else {
         (quote!(void), quote!((_) {}))
     };

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -1,23 +1,20 @@
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::Read;
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::Metadata;
-
 use genco::fmt;
 use genco::prelude::*;
 use serde::{Deserialize, Serialize};
 use toml;
-use uniffi_bindgen::BindgenCrateConfigSupplier;
-use uniffi_bindgen::Component;
+use uniffi_bindgen::{BindgenCrateConfigSupplier, BindingGenerator, Component, ComponentInterface};
+
 // use uniffi_bindgen::MergeWith;
 use self::render::Renderer;
 use self::types::TypeHelpersRenderer;
 use crate::gen::oracle::DartCodeOracle;
-use uniffi_bindgen::{BindingGenerator, ComponentInterface};
 
 mod callback_interface;
 mod code_type;
@@ -93,11 +90,7 @@ pub struct DartWrapper<'a> {
 impl<'a> DartWrapper<'a> {
     pub fn new(ci: &'a ComponentInterface, config: &'a Config) -> Self {
         let type_renderer = TypeHelpersRenderer::new(ci);
-        DartWrapper {
-            ci,
-            config,
-            type_renderer,
-        }
+        DartWrapper { ci, config, type_renderer }
     }
 
     fn generate(&self) -> dart::Tokens {
@@ -252,10 +245,7 @@ impl BindingGenerator for DartBindingGenerator {
         // Run full Dart formatter on the output directory as a best-effort step.
         // This is non-fatal: failures will only emit a warning.
         let mut format_command = Command::new("dart");
-        format_command
-            .current_dir(&settings.out_dir)
-            .arg("format")
-            .arg(".");
+        format_command.current_dir(&settings.out_dir).arg("format").arg(".");
         match format_command.spawn().and_then(|mut c| c.wait()) {
             Ok(status) if status.success() => {}
             Ok(_) | Err(_) => {
@@ -268,12 +258,10 @@ impl BindingGenerator for DartBindingGenerator {
     }
 
     fn new_config(&self, root_toml: &toml::value::Value) -> Result<Self::Config> {
-        Ok(
-            match root_toml.get("bindings").and_then(|b| b.get("dart")) {
-                Some(v) => v.clone().try_into()?,
-                None => Default::default(),
-            },
-        )
+        Ok(match root_toml.get("bindings").and_then(|b| b.get("dart")) {
+            Some(v) => v.clone().try_into()?,
+            None => Default::default(),
+        })
     }
 
     fn update_component_configs(
@@ -283,10 +271,7 @@ impl BindingGenerator for DartBindingGenerator {
     ) -> Result<()> {
         for c in &mut *components {
             c.config.cdylib_name.get_or_insert_with(|| {
-                settings
-                    .cdylib
-                    .clone()
-                    .unwrap_or_else(|| format!("uniffi_{}", c.ci.namespace()))
+                settings.cdylib.clone().unwrap_or_else(|| format!("uniffi_{}", c.ci.namespace()))
             });
         }
         Ok(())
@@ -330,17 +315,12 @@ impl ConfigFileSupplier {
                             && !t.is_custom_build()
                     })
                     .filter_map(|t| {
-                        p.manifest_path
-                            .parent()
-                            .map(|p| (t.name.replace('-', "_"), p.to_owned()))
+                        p.manifest_path.parent().map(|p| (t.name.replace('-', "_"), p.to_owned()))
                     })
             })
             .collect();
 
-        Self {
-            config_file_path,
-            crate_paths,
-        }
+        Self { config_file_path, crate_paths }
     }
 }
 
@@ -376,9 +356,7 @@ impl BindgenCrateConfigSupplier for ConfigFileSupplier {
 
     fn get_toml_path(&self, crate_name: &str) -> Option<Utf8PathBuf> {
         // This implementation matches uniffi_bindgen's CrateConfigSupplier::get_toml_path
-        self.crate_paths
-            .get(crate_name)
-            .map(|p| p.join("uniffi.toml"))
+        self.crate_paths.get(crate_name).map(|p| p.join("uniffi.toml"))
     }
 }
 

--- a/src/gen/objects.rs
+++ b/src/gen/objects.rs
@@ -1,20 +1,18 @@
-use genco::prelude::*;
 use std::fmt::Debug;
 
-use crate::gen::callback_interface::{
-    generate_callback_functions, generate_callback_interface,
-    generate_callback_interface_vtable_init_function, generate_callback_vtable_interface,
-};
-use crate::gen::CodeType;
+use genco::prelude::*;
 use heck::ToLowerCamelCase;
 use uniffi_bindgen::interface::{AsType, Method, Object, ObjectImpl, UniffiTrait};
 use uniffi_bindgen::pipeline::general::nodes::Literal;
 
-use crate::gen::oracle::{AsCodeType, DartCodeOracle};
-use crate::gen::render::AsRenderable;
-use crate::gen::render::{Renderable, TypeHelperRenderer};
-
 use super::stream::generate_stream;
+use crate::gen::callback_interface::{
+    generate_callback_functions, generate_callback_interface,
+    generate_callback_interface_vtable_init_function, generate_callback_vtable_interface,
+};
+use crate::gen::oracle::{AsCodeType, DartCodeOracle};
+use crate::gen::render::{AsRenderable, Renderable, TypeHelperRenderer};
+use crate::gen::CodeType;
 
 #[derive(Debug)]
 pub struct ObjectCodeType {
@@ -109,11 +107,8 @@ pub fn generate_object(obj: &Object, type_helper: &dyn TypeHelperRenderer) -> da
 
     // Stream workaround, make it more elegant later
 
-    let stream_glue = if obj.name().contains("StreamExt") {
-        generate_stream(obj, type_helper)
-    } else {
-        quote!()
-    };
+    let stream_glue =
+        if obj.name().contains("StreamExt") { generate_stream(obj, type_helper) } else { quote!() };
 
     let mut constructor_definitions: Vec<dart::Tokens> = Vec::new();
     let mut async_constructor_factories: Vec<dart::Tokens> = Vec::new();
@@ -235,10 +230,8 @@ pub fn generate_object(obj: &Object, type_helper: &dyn TypeHelperRenderer) -> da
     };
 
     // Generate toString() method for error interfaces
-    let has_display_trait = obj
-        .uniffi_traits()
-        .iter()
-        .any(|t| matches!(t, UniffiTrait::Display { .. }));
+    let has_display_trait =
+        obj.uniffi_traits().iter().any(|t| matches!(t, UniffiTrait::Display { .. }));
 
     let to_string_method: dart::Tokens =
         if is_error_interface && !obj.is_trait_interface() && !has_display_trait {
@@ -379,10 +372,7 @@ fn generate_callback_trait_rust_method(
         .collect::<Vec<_>>();
 
     let (ret, lifter) = if let Some(ret) = method.return_type() {
-        (
-            ret.as_renderable().render_type(ret, type_helper),
-            quote!($(ret.as_codetype().lift())),
-        )
+        (ret.as_renderable().render_type(ret, type_helper), quote!($(ret.as_codetype().lift())))
     } else {
         (quote!(void), quote!((_) {}))
     };
@@ -464,10 +454,7 @@ pub fn generate_method(func: &Method, type_helper: &dyn TypeHelperRenderer) -> d
     };
 
     let (ret, lifter) = if let Some(ret) = func.return_type() {
-        (
-            ret.as_renderable().render_type(ret, type_helper),
-            quote!($(ret.as_codetype().lift())),
-        )
+        (ret.as_renderable().render_type(ret, type_helper), quote!($(ret.as_codetype().lift())))
     } else {
         (quote!(void), quote!((_) {}))
     };
@@ -674,15 +661,11 @@ fn generate_trait_object(obj: &Object, type_helper: &dyn TypeHelperRenderer) -> 
     let ffi_object_free_name = obj.ffi_object_free().name();
     let ffi_object_clone_name = obj.ffi_object_clone().name();
 
-    let abstract_methods = obj
-        .methods()
-        .into_iter()
-        .map(|method| generate_interface_method(method, type_helper));
+    let abstract_methods =
+        obj.methods().into_iter().map(|method| generate_interface_method(method, type_helper));
 
-    let concrete_methods = obj
-        .methods()
-        .into_iter()
-        .map(|method| generate_method(method, type_helper));
+    let concrete_methods =
+        obj.methods().into_iter().map(|method| generate_method(method, type_helper));
 
     quote! {
         abstract class $cls_name {

--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -2,16 +2,12 @@ use genco::lang::dart;
 use genco::quote;
 use heck::{ToLowerCamelCase, ToUpperCamelCase};
 use uniffi_bindgen::interface::ffi::ExternalFfiMetadata;
-use uniffi_bindgen::interface::{Argument, Object, ObjectImpl};
-
-use crate::gen::CodeType;
-use uniffi_bindgen::interface::{AsType, Callable, FfiType, Type};
+use uniffi_bindgen::interface::{Argument, AsType, Callable, FfiType, Object, ObjectImpl, Type};
 use uniffi_bindgen::ComponentInterface;
-
-use crate::gen::primitives;
 
 // use super::render::{AsRenderable, Renderable};
 use super::{callback_interface, compounds, custom, enums, objects, records};
+use crate::gen::{primitives, CodeType};
 
 pub struct DartCodeOracle;
 
@@ -71,10 +67,7 @@ impl DartCodeOracle {
 
     /// Get the idiomatic Dart rendering of an FFI callback function name
     pub fn ffi_callback_name(nm: &str) -> String {
-        format!(
-            "Pointer<NativeFunction<{}>>",
-            Self::callback_name(&nm.to_upper_camel_case())
-        )
+        format!("Pointer<NativeFunction<{}>>", Self::callback_name(&nm.to_upper_camel_case()))
     }
 
     /// Helper method to generate the callback name based on `Type`.
@@ -122,9 +115,8 @@ impl DartCodeOracle {
 
     /// Helper method to fully qualify imports of external `RustBuffer`s
     fn rust_buffer_name_with_path(module_path: &str, ci: &ComponentInterface) -> dart::Tokens {
-        let namespace = ci
-            .namespace_for_module_path(module_path)
-            .expect("module path should exist");
+        let namespace =
+            ci.namespace_for_module_path(module_path).expect("module path should exist");
         if namespace != ci.namespace() {
             return quote!($(namespace).RustBuffer);
         }
@@ -304,11 +296,7 @@ impl DartCodeOracle {
                     let inner = DartCodeOracle::dart_type_label(Some(inner_type));
                     quote!(List<$inner>)
                 }
-                Type::Map {
-                    key_type,
-                    value_type,
-                    ..
-                } => {
+                Type::Map { key_type, value_type, .. } => {
                     let key = DartCodeOracle::dart_type_label(Some(key_type));
                     let value = DartCodeOracle::dart_type_label(Some(value_type));
                     quote!(Map<$key, $value>)
@@ -602,10 +590,7 @@ impl DartCodeOracle {
     pub fn lower_arg_with_callback_handling(arg: &Argument) -> dart::Tokens {
         let base_lower = Self::type_lower_fn(&arg.as_type(), quote!($(Self::var_name(arg.name()))));
         match arg.as_type() {
-            Type::Object {
-                imp: ObjectImpl::CallbackTrait,
-                ..
-            } => base_lower,
+            Type::Object { imp: ObjectImpl::CallbackTrait, .. } => base_lower,
             Type::CallbackInterface { .. } => quote!($base_lower.address),
             _ => base_lower,
         }
@@ -725,33 +710,23 @@ impl<T: AsType> AsCodeType for T {
             Type::Duration => Box::new(primitives::DurationCodeType),
             Type::Bytes => Box::new(primitives::BytesCodeType),
             Type::Object { name, imp, .. } => Box::new(objects::ObjectCodeType::new(name, imp)),
-            Type::Optional { inner_type } => Box::new(compounds::OptionalCodeType::new(
-                self.as_type(),
-                *inner_type,
-            )),
-            Type::Sequence { inner_type } => Box::new(compounds::SequenceCodeType::new(
-                self.as_type(),
-                *inner_type,
-            )),
-            Type::Map {
-                key_type,
-                value_type,
-                ..
-            } => Box::new(compounds::MapCodeType::new(
-                self.as_type(),
-                *key_type,
-                *value_type,
-            )),
+            Type::Optional { inner_type } => {
+                Box::new(compounds::OptionalCodeType::new(self.as_type(), *inner_type))
+            }
+            Type::Sequence { inner_type } => {
+                Box::new(compounds::SequenceCodeType::new(self.as_type(), *inner_type))
+            }
+            Type::Map { key_type, value_type, .. } => {
+                Box::new(compounds::MapCodeType::new(self.as_type(), *key_type, *value_type))
+            }
             Type::Enum { name, .. } => Box::new(enums::EnumCodeType::new(name)),
             Type::Record { name, .. } => Box::new(records::RecordCodeType::new(name)),
-            Type::CallbackInterface { name, .. } => Box::new(
-                callback_interface::CallbackInterfaceCodeType::new(name, self.as_type()),
-            ),
-            Type::Custom {
-                name,
-                module_path,
-                builtin,
-            } => Box::new(custom::CustomCodeType::new(name, module_path, builtin)),
+            Type::CallbackInterface { name, .. } => {
+                Box::new(callback_interface::CallbackInterfaceCodeType::new(name, self.as_type()))
+            }
+            Type::Custom { name, module_path, builtin } => {
+                Box::new(custom::CustomCodeType::new(name, module_path, builtin))
+            }
             _ => todo!("As Type for Type::{:?}", self.as_type()),
         }
     }

--- a/src/gen/primitives/boolean.rs
+++ b/src/gen/primitives/boolean.rs
@@ -1,11 +1,8 @@
-use crate::gen::{
-    quote,
-    render::{Renderable, TypeHelperRenderer},
-};
-
 use genco::lang::dart;
 
 use super::paste;
+use crate::gen::quote;
+use crate::gen::render::{Renderable, TypeHelperRenderer};
 
 impl_code_type_for_primitive!(BooleanCodeType, "bool", "Bool");
 

--- a/src/gen/primitives/duration.rs
+++ b/src/gen/primitives/duration.rs
@@ -1,10 +1,8 @@
-use crate::gen::{
-    quote,
-    render::{Renderable, TypeHelperRenderer},
-};
+use genco::lang::dart;
 
 use super::paste;
-use genco::lang::dart;
+use crate::gen::quote;
+use crate::gen::render::{Renderable, TypeHelperRenderer};
 
 impl_code_type_for_primitive!(DurationCodeType, "Duration", "Duration");
 

--- a/src/gen/primitives/mod.rs
+++ b/src/gen/primitives/mod.rs
@@ -4,10 +4,11 @@ mod boolean;
 mod duration;
 mod string;
 
-use crate::gen::render::{Renderable, TypeHelperRenderer};
-use crate::gen::CodeType;
+pub use boolean::BooleanCodeType;
+pub use duration::DurationCodeType;
 use genco::prelude::*;
 use paste::paste;
+pub use string::StringCodeType;
 use uniffi_bindgen::interface::{
     DefaultValue as InterfaceDefaultValue, Literal as InterfaceLiteral, Radix as InterfaceRadix,
     Type as InterfaceType,
@@ -16,9 +17,8 @@ use uniffi_bindgen::pipeline::general::nodes::{
     Literal as PipelineLiteral, Radix as PipelineRadix, Type as PipelineType, TypeNode,
 };
 
-pub use boolean::BooleanCodeType;
-pub use duration::DurationCodeType;
-pub use string::StringCodeType;
+use crate::gen::render::{Renderable, TypeHelperRenderer};
+use crate::gen::CodeType;
 
 pub(crate) fn escape_dart_string(value: &str) -> String {
     value
@@ -153,15 +153,7 @@ impl_code_type_for_primitive!(Float64CodeType, "double", "Double64");
 impl_renderable_for_primitive!(BytesCodeType, "Uint8List", "Uint8List");
 impl_renderable_for_primitive!(Int8CodeType, "int", "Int8", 1, -128, 127, "i8");
 impl_renderable_for_primitive!(Int16CodeType, "int", "Int16", 2, -32768, 32767, "i16");
-impl_renderable_for_primitive!(
-    Int32CodeType,
-    "int",
-    "Int32",
-    4,
-    -2147483648,
-    2147483647,
-    "i32"
-);
+impl_renderable_for_primitive!(Int32CodeType, "int", "Int32", 4, -2147483648, 2147483647, "i32");
 impl_renderable_for_primitive!(
     Int64CodeType,
     "int",

--- a/src/gen/primitives/string.rs
+++ b/src/gen/primitives/string.rs
@@ -1,10 +1,7 @@
-use crate::gen::{
-    quote,
-    render::{Renderable, TypeHelperRenderer},
-};
-
-use crate::gen::CodeType;
 use genco::lang::dart;
+
+use crate::gen::render::{Renderable, TypeHelperRenderer};
+use crate::gen::{quote, CodeType};
 
 #[derive(Debug)]
 pub struct StringCodeType;

--- a/src/gen/records.rs
+++ b/src/gen/records.rs
@@ -1,11 +1,12 @@
+use genco::prelude::*;
+use uniffi_bindgen::interface::{AsType, Record, Type};
+use uniffi_bindgen::pipeline::general::nodes::Literal as PipelineLiteral;
+
 use super::oracle::{AsCodeType, DartCodeOracle};
 use super::primitives::render_interface_default_value;
 use super::render::{Renderable, TypeHelperRenderer};
 use super::types::generate_type;
 use crate::gen::CodeType;
-use genco::prelude::*;
-use uniffi_bindgen::interface::{AsType, Record, Type};
-use uniffi_bindgen::pipeline::general::nodes::Literal as PipelineLiteral;
 
 #[derive(Debug)]
 pub struct RecordCodeType {

--- a/src/gen/render/mod.rs
+++ b/src/gen/render/mod.rs
@@ -1,8 +1,10 @@
-use super::{callback_interface, compounds, custom, enums, primitives, records};
-use super::{objects, oracle::AsCodeType};
-use genco::{lang::dart, quote};
+use genco::lang::dart;
+use genco::quote;
 use uniffi_bindgen::interface::{AsType, Enum, Object, Record, Type};
 use uniffi_bindgen::ComponentInterface;
+
+use super::oracle::AsCodeType;
+use super::{callback_interface, compounds, custom, enums, objects, primitives, records};
 
 pub trait Renderer<T> {
     fn render(&self) -> T;
@@ -43,10 +45,7 @@ pub trait Renderable {
             Type::Sequence { inner_type } => {
                 quote!(List<$(&self.render_type(inner_type, type_helper))>)
             }
-            Type::Map {
-                key_type,
-                value_type,
-            } => {
+            Type::Map { key_type, value_type } => {
                 quote!(Map<$(&self.render_type(key_type, type_helper)), $(&self.render_type(value_type, type_helper))>)
             }
             Type::Enum { name, .. } => quote!($(DartCodeOracle::class_name(name))),
@@ -89,32 +88,23 @@ impl<T: AsType> AsRenderable for T {
             Type::Duration => Box::new(primitives::DurationCodeType),
             Type::Bytes => Box::new(primitives::BytesCodeType),
             Type::Object { name, imp, .. } => Box::new(objects::ObjectCodeType::new(name, imp)),
-            Type::Optional { inner_type } => Box::new(compounds::OptionalCodeType::new(
-                self.as_type(),
-                *inner_type,
-            )),
-            Type::Sequence { inner_type } => Box::new(compounds::SequenceCodeType::new(
-                self.as_type(),
-                *inner_type,
-            )),
-            Type::Map {
-                key_type,
-                value_type,
-            } => Box::new(compounds::MapCodeType::new(
-                self.as_type(),
-                *key_type,
-                *value_type,
-            )),
+            Type::Optional { inner_type } => {
+                Box::new(compounds::OptionalCodeType::new(self.as_type(), *inner_type))
+            }
+            Type::Sequence { inner_type } => {
+                Box::new(compounds::SequenceCodeType::new(self.as_type(), *inner_type))
+            }
+            Type::Map { key_type, value_type } => {
+                Box::new(compounds::MapCodeType::new(self.as_type(), *key_type, *value_type))
+            }
             Type::Enum { name, .. } => Box::new(enums::EnumCodeType::new(name)),
             Type::Record { name, .. } => Box::new(records::RecordCodeType::new(name)),
-            Type::Custom {
-                name,
-                module_path,
-                builtin,
-            } => Box::new(custom::CustomCodeType::new(name, module_path, builtin)),
-            Type::CallbackInterface { name, .. } => Box::new(
-                callback_interface::CallbackInterfaceCodeType::new(name, self.as_type()),
-            ),
+            Type::Custom { name, module_path, builtin } => {
+                Box::new(custom::CustomCodeType::new(name, module_path, builtin))
+            }
+            Type::CallbackInterface { name, .. } => {
+                Box::new(callback_interface::CallbackInterfaceCodeType::new(name, self.as_type()))
+            }
             _ => todo!("Renderable for Type::{:?}", self.as_type()),
         }
     }

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -2,11 +2,12 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet};
 
 use genco::prelude::*;
-use uniffi_bindgen::interface::{AsType, Callable};
-use uniffi_bindgen::{interface::Type, ComponentInterface};
+use uniffi_bindgen::interface::{AsType, Callable, Type};
+use uniffi_bindgen::ComponentInterface;
 
+use super::oracle::AsCodeType;
 use super::render::{AsRenderable, Renderer, TypeHelperRenderer};
-use super::{enums, functions, objects, oracle::AsCodeType, records};
+use super::{enums, functions, objects, records};
 use crate::gen::oracle::DartCodeOracle;
 
 type FunctionDefinition = dart::Tokens;
@@ -144,9 +145,7 @@ impl Renderer<(FunctionDefinition, dart::Tokens)> for TypeHelpersRenderer<'_> {
             .ci
             .iter_external_types()
             .map(|ty| {
-                self.ci
-                    .namespace_for_type(ty)
-                    .expect("external type should have module_path")
+                self.ci.namespace_for_type(ty).expect("external type should have module_path")
             })
             .collect::<BTreeSet<_>>();
         // The second import statement uses a library prefix, to distinguish conflicting identifiers e.g. RustBuffer vs. ext.RustBuffer
@@ -603,10 +602,9 @@ pub fn generate_type(ty: &Type) -> dart::Tokens {
         Type::Boolean => quote!(bool),
         Type::Optional { inner_type } => quote!($(generate_type(inner_type))?),
         Type::Sequence { inner_type } => quote!(List<$(generate_type(inner_type))>),
-        Type::Map {
-            key_type,
-            value_type,
-        } => quote!(Map<$(generate_type(key_type)), $(generate_type(value_type))>),
+        Type::Map { key_type, value_type } => {
+            quote!(Map<$(generate_type(key_type)), $(generate_type(value_type))>)
+        }
         Type::Enum { name, .. } => quote!($(DartCodeOracle::class_name(name))),
         Type::Duration => quote!(Duration),
         Type::Record { name, .. } => quote!($name),

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,13 +1,15 @@
-use crate::gen;
-use anyhow::{bail, Result};
-use camino::{Utf8Path, Utf8PathBuf};
-use camino_tempfile::tempdir;
 use std::fs::{copy, create_dir_all, File};
 use std::io::Write;
 use std::process::Command;
 use std::thread;
 use std::time::Duration;
+
+use anyhow::{bail, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use camino_tempfile::tempdir;
 use uniffi_testing::UniFFITestHelper;
+
+use crate::gen;
 
 // A source to compile for a test
 #[derive(Debug)]
@@ -259,11 +261,7 @@ void main(List<String> args) async {{
     // Copy fixture test files to output directory
     let test_glob_pattern = "test/*.dart";
     for file in glob::glob(test_glob_pattern)?.filter_map(Result::ok) {
-        let filename = file
-            .file_name()
-            .expect("bad filename")
-            .to_str()
-            .expect("non-UTF8 filename");
+        let filename = file.file_name().expect("bad filename").to_str().expect("non-UTF8 filename");
         copy(&file, test_outdir.join(filename))?;
     }
 

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  projectRootFile = "flake.nix";
+
+  programs = {
+    nixfmt.enable = true;
+  };
+}

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,8 +1,29 @@
-{ ... }:
+{ pkgs, ... }:
 {
   projectRootFile = "flake.nix";
 
   programs = {
+    dart-format.enable = true;
     nixfmt.enable = true;
+    rustfmt = {
+      enable = true;
+      package = pkgs.rustToolchains.stable;
+      edition = "2021";
+    };
+  };
+
+  settings = {
+    excludes = [
+      "experiments/**"
+    ];
+    formatter = {
+      dart-format.excludes = [
+        "fixtures/**/test/*.dart"
+      ];
+      rustfmt.options = [
+        "--config-path"
+        "./rustfmt.toml"
+      ];
+    };
   };
 }

--- a/uniffi_dart_macro/src/lib.rs
+++ b/uniffi_dart_macro/src/lib.rs
@@ -1,7 +1,8 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
 use stringcase::pascal_case;
-use syn::{parse::Parse, parse_macro_input, Ident, ItemFn, LitStr, Type};
+use syn::parse::Parse;
+use syn::{parse_macro_input, Ident, ItemFn, LitStr, Type};
 
 struct StreamAttr {
     item_type: Type,
@@ -28,10 +29,7 @@ impl Parse for StreamAttr {
 
             input.parse::<syn::Token![=]>()?;
             if runtime.is_some() {
-                return Err(syn::Error::new(
-                    ident.span(),
-                    "duplicate `runtime` argument",
-                ));
+                return Err(syn::Error::new(ident.span(), "duplicate `runtime` argument"));
             }
 
             let value: LitStr = input.parse()?;


### PR DESCRIPTION
This PR adds a Nix flake for reproducible (not fully reproducible yet)  local development shells and lightweight CI validation. It provides `.#msrv`, `.#stable`, and `.#nightly` shells with Rust, Dart, `cargo-nextest`, `rust-analyzer`, `cargo-watch`, `cargo-edit`, `taplo`, and `codespell`, plus direnv support through `.envrc`. The Nix CI workflow runs `nix flake check` and verifies the availability of shell tools

The setup is intentionally scoped to this repository inspired by  copying rust-payjoin. It does not add pure Cargo derivations yet because this repo does not currently commit `Cargo.lock`, and the UniFFI fixture tests dynamically generate Dart packages and run `dart test`.

A  follow-up PR would be to commit `Cargo.lock` for this workspace, remove `/Cargo.lock` from `.gitignore`, and then tighten CI with `--locked`. Once the lockfile policy is settled, we can add Cargo-focused flake checks with `crane`, such as `cargo check`, `clippy`, and no-run test builds. Full pure-Nix fixture tests should wait until Dart/Pub dependency pinning is handled.

## Testing

- `nix fmt -- --ci`
- `nix flake check -L`
- `nix develop .#msrv -c bash -lc 'rustc --version && cargo --version && cargo nextest --version && dart --version'`
- `nix develop .#stable -c bash -lc 'rustc --version && cargo --version && cargo nextest --version && dart --version'`
- `nix develop .#nightly -c bash -lc 'rustc --version && cargo --version && cargo nextest --version && dart --version'`
- `nix develop .#stable -c cargo fmt --all -- --check`
- `nix develop .#msrv -c cargo nextest run -p hello_world --nocapture`
