### PR TITLE
feat: preserve callable defaults

### DIFF
--- a/fixtures/proc-macro-no-implicit-prelude/test/proc_macro_no_implicit_prelude_test.dart
+++ b/fixtures/proc-macro-no-implicit-prelude/test/proc_macro_no_implicit_prelude_test.dart
@@ -180,13 +180,19 @@ void main() {
     });
 
     test('explicit values for defaultable APIs', () {
+      expect(doubleWithDefault(), equals(42));
       expect(doubleWithDefault(num: 21), equals(42));
       expect(doubleWithDefault(num: 10), equals(20));
 
       final objWithDefaults = ObjectWithDefaults(num: 30);
+      expect(objWithDefaults.addToNum(), equals(42));
       expect(objWithDefaults.addToNum(other: 12), equals(42));
       expect(objWithDefaults.addToNum(other: 5), equals(35));
       objWithDefaults.dispose();
+
+      final defaultObjWithDefaults = ObjectWithDefaults();
+      expect(defaultObjWithDefaults.addToNum(other: 12), equals(42));
+      defaultObjWithDefaults.dispose();
     });
 
     test('string operations without prelude', () {

--- a/src/gen/defaults.rs
+++ b/src/gen/defaults.rs
@@ -1,0 +1,35 @@
+use genco::prelude::*;
+use uniffi_bindgen::interface::{Argument, AsType, DefaultValue, Type};
+
+use super::oracle::DartCodeOracle;
+use super::primitives::render_interface_default_value;
+
+fn enum_name_from_type(ty: &Type) -> Option<String> {
+    match ty {
+        Type::Enum { name, .. } => Some(DartCodeOracle::class_name(name)),
+        Type::Optional { inner_type } => enum_name_from_type(inner_type),
+        _ => None,
+    }
+}
+
+pub(crate) fn render_default_value(default_value: &DefaultValue, ty: &Type) -> Option<String> {
+    render_interface_default_value(default_value, ty, |ty, variant| {
+        let enum_name = enum_name_from_type(ty)?;
+        let variant_name = DartCodeOracle::enum_variant_name(variant);
+        Some(format!("{enum_name}.{variant_name}"))
+    })
+}
+
+pub(crate) fn render_argument_param(arg: &Argument, type_tokens: dart::Tokens) -> dart::Tokens {
+    let name = DartCodeOracle::var_name(arg.name());
+
+    if let Some(default_value) = arg.default_value() {
+        if let Some(default_expr) = render_default_value(default_value, &arg.as_type()) {
+            quote!($type_tokens $name = $(default_expr))
+        } else {
+            quote!(required $type_tokens $name)
+        }
+    } else {
+        quote!(required $type_tokens $name)
+    }
+}

--- a/src/gen/functions.rs
+++ b/src/gen/functions.rs
@@ -2,6 +2,7 @@ use genco::prelude::*;
 use heck::ToLowerCamelCase;
 use uniffi_bindgen::interface::{AsType, Function};
 
+use super::defaults::render_argument_param;
 use super::oracle::AsCodeType;
 use super::render::TypeHelperRenderer;
 use crate::gen::oracle::DartCodeOracle;
@@ -11,7 +12,12 @@ pub fn generate_function(func: &Function, type_helper: &dyn TypeHelperRenderer) 
     let args = if func.arguments().is_empty() {
         quote!()
     } else {
-        quote!({$(for arg in &func.arguments() => required $(&arg.as_renderable().render_type(&arg.as_type(), type_helper)) $(DartCodeOracle::var_name(arg.name())),)})
+        quote!({$(for arg in &func.arguments() =>
+            $(render_argument_param(
+                arg,
+                arg.as_renderable().render_type(&arg.as_type(), type_helper)
+            )),
+        )})
     };
 
     let (ret, lifter) = if let Some(ret) = func.return_type() {

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -20,6 +20,7 @@ mod callback_interface;
 mod code_type;
 mod compounds;
 mod custom;
+mod defaults;
 mod enums;
 mod functions;
 mod objects;

--- a/src/gen/objects.rs
+++ b/src/gen/objects.rs
@@ -5,6 +5,7 @@ use heck::ToLowerCamelCase;
 use uniffi_bindgen::interface::{AsType, Method, Object, ObjectImpl, UniffiTrait};
 use uniffi_bindgen::pipeline::general::nodes::Literal;
 
+use super::defaults::render_argument_param;
 use super::stream::generate_stream;
 use crate::gen::callback_interface::{
     generate_callback_functions, generate_callback_interface,
@@ -138,7 +139,10 @@ pub fn generate_object(obj: &Object, type_helper: &dyn TypeHelperRenderer) -> da
             quote!()
         } else {
             quote!({$(for arg in constructor.arguments() =>
-                required $(DartCodeOracle::dart_type_label(Some(&arg.as_type()))) $(DartCodeOracle::var_name(arg.name())),
+                $(render_argument_param(
+                    arg,
+                    quote!($(DartCodeOracle::dart_type_label(Some(&arg.as_type()))))
+                )),
             )})
         };
 
@@ -450,7 +454,12 @@ pub fn generate_method(func: &Method, type_helper: &dyn TypeHelperRenderer) -> d
     let args = if func.arguments().is_empty() {
         quote!()
     } else {
-        quote!({$(for arg in &func.arguments() => required $(&arg.as_renderable().render_type(&arg.as_type(), type_helper)) $(DartCodeOracle::var_name(arg.name())),)})
+        quote!({$(for arg in &func.arguments() =>
+            $(render_argument_param(
+                arg,
+                arg.as_renderable().render_type(&arg.as_type(), type_helper)
+            )),
+        )})
     };
 
     let (ret, lifter) = if let Some(ret) = func.return_type() {
@@ -775,7 +784,10 @@ fn generate_interface_method(
         quote!()
     } else {
         quote!({$(for arg in method.arguments() =>
-            required $(&arg.as_renderable().render_type(&arg.as_type(), type_helper)) $(DartCodeOracle::var_name(arg.name())),
+            $(render_argument_param(
+                arg,
+                arg.as_renderable().render_type(&arg.as_type(), type_helper)
+            )),
         )})
     };
     let ret_type = method_return_type_tokens(method, type_helper);

--- a/src/gen/records.rs
+++ b/src/gen/records.rs
@@ -2,8 +2,8 @@ use genco::prelude::*;
 use uniffi_bindgen::interface::{AsType, Record, Type};
 use uniffi_bindgen::pipeline::general::nodes::Literal as PipelineLiteral;
 
+use super::defaults::render_default_value;
 use super::oracle::{AsCodeType, DartCodeOracle};
-use super::primitives::render_interface_default_value;
 use super::render::{Renderable, TypeHelperRenderer};
 use super::types::generate_type;
 use crate::gen::CodeType;
@@ -36,14 +36,6 @@ impl CodeType for RecordCodeType {
     }
 }
 
-fn enum_name_from_type(ty: &Type) -> Option<String> {
-    match ty {
-        Type::Enum { name, .. } => Some(DartCodeOracle::class_name(name)),
-        Type::Optional { inner_type } => enum_name_from_type(inner_type),
-        _ => None,
-    }
-}
-
 impl Renderable for RecordCodeType {
     fn render_type_helper(&self, type_helper: &dyn TypeHelperRenderer) -> dart::Tokens {
         if type_helper.check(&self.id) {
@@ -65,15 +57,7 @@ pub fn generate_record(obj: &Record, type_helper: &dyn TypeHelperRenderer) -> da
         .map(|field| {
             let name = DartCodeOracle::var_name(field.name());
             if let Some(default_value) = field.default_value() {
-                if let Some(default_expr) = render_interface_default_value(
-                    default_value,
-                    &field.as_type(),
-                    |ty, variant| {
-                        let enum_name = enum_name_from_type(ty)?;
-                        let variant_name = DartCodeOracle::enum_variant_name(variant);
-                        Some(format!("{enum_name}.{variant_name}"))
-                    },
-                ) {
+                if let Some(default_expr) = render_default_value(default_value, &field.as_type()) {
                     quote!(this.$name = $(default_expr))
                 } else {
                     // Fallback to required when a default is present but cannot be rendered safely.


### PR DESCRIPTION
My attempt to address #142 any/all feedback welcome

## Summary

- render UniFFI default values on generated Dart function, constructor, and method parameters
- share default rendering between record fields and callable arguments
- add coverage for omitting defaulted callable arguments
