### PR TITLE
Constrain toml dep to be consistent with other uniffi crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ uniffi_bindgen = { workspace = true }
 camino = "1"
 cargo_metadata = "0.18"
 serde = "1"
-toml = "0.9"
+toml = ">=0.8, <=0.9"
 genco = "0.17.5"
 proc-macro2 = "1.0.66"
 


### PR DESCRIPTION
I was trying to pin the transient deps within rust-payjoin to their minimal versions but I got conflicts between this and https://github.com/chavic/uniffi-bindgen-cs/pull/1 where the toml deps were all inconsistent. This attempts to lock them all to the same contraints.