### PR TITLE
Fixup for name mangling in all-caps acronym identifiers

### DIFF
--- a/fixtures/custom_types/src/api.udl
+++ b/fixtures/custom_types/src/api.udl
@@ -12,7 +12,22 @@ dictionary ZenEngineResponse {
     record<string, ZenEngineTrace>? trace;
 };
 
+// Acronym-named custom type + records, to guard identifier-casing regressions.
+[Custom]
+typedef string URLString;
+
+dictionary HTTPMetadata {
+    URLString url;
+    u32 status;
+};
+
+dictionary APIResult {
+    HTTPMetadata primary;
+    HTTPMetadata? fallback;
+};
+
 namespace custom_types {
     ZenEngineResponse get_zen_engine_response();
     ZenEngineResponse return_zen_engine_response(ZenEngineResponse response);
+    APIResult roundtrip_api_result(APIResult value);
 };

--- a/fixtures/custom_types/src/lib.rs
+++ b/fixtures/custom_types/src/lib.rs
@@ -1,3 +1,9 @@
+// This fixture deliberately uses non-idiomatic, all-caps-acronym type names
+// (`URLString`, `HTTPMetadata`, `APIResult`) to exercise identifier-casing in
+// the Dart generator. That is exactly what `clippy::upper_case_acronyms`
+// (in aggressive mode) would flag, so allow it here on purpose.
+#![allow(clippy::upper_case_acronyms)]
+
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,6 +37,33 @@ pub fn get_zen_engine_response() -> ZenEngineResponse {
 
 pub fn return_zen_engine_response(response: ZenEngineResponse) -> ZenEngineResponse {
     response
+}
+
+// Regression coverage for identifier casing of names containing all-caps
+// acronyms, so `class_name()` normalizes `URLString` to `UrlString`, for example.
+// Here we're testing several examples in different positions.
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct URLString(pub String);
+
+uniffi::custom_newtype!(URLString, String);
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HTTPMetadata {
+    pub url: URLString,
+    pub status: u32,
+}
+
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct APIResult {
+    pub primary: HTTPMetadata,
+    pub fallback: Option<HTTPMetadata>,
+}
+
+pub fn roundtrip_api_result(value: APIResult) -> APIResult {
+    value
 }
 
 uniffi::include_scaffolding!("api");

--- a/fixtures/custom_types/test/custom_types_test.dart
+++ b/fixtures/custom_types/test/custom_types_test.dart
@@ -30,4 +30,18 @@ void main() {
     expect(roundTrip.trace!['manual']!.id, equals('manual'));
     expect(roundTrip.trace!['manual']!.value, orderedEquals([6, 5, 4]));
   });
+
+  test('acronym-named custom and record types round trip', () {
+    final value = ApiResult(
+      primary: HttpMetadata(url: 'https://primary.example', status: 200),
+      fallback: HttpMetadata(url: 'https://fallback.example', status: 503),
+    );
+
+    final roundTrip = roundtripApiResult(value: value);
+
+    expect(roundTrip.primary.url, equals('https://primary.example'));
+    expect(roundTrip.primary.status, equals(200));
+    expect(roundTrip.fallback!.url, equals('https://fallback.example'));
+    expect(roundTrip.fallback!.status, equals(503));
+  });
 }

--- a/src/gen/records.rs
+++ b/src/gen/records.rs
@@ -58,7 +58,7 @@ impl Renderable for RecordCodeType {
 
 pub fn generate_record(obj: &Record, type_helper: &dyn TypeHelperRenderer) -> dart::Tokens {
     let cls_name = &DartCodeOracle::class_name(obj.name());
-    let ffi_conv_name = &DartCodeOracle::class_name(&obj.as_codetype().ffi_converter_name());
+    let ffi_conv_name = &obj.as_codetype().ffi_converter_name();
     let constructor_params: Vec<dart::Tokens> = obj
         .fields()
         .iter()

--- a/src/gen/render/mod.rs
+++ b/src/gen/render/mod.rs
@@ -49,10 +49,10 @@ pub trait Renderable {
                 quote!(Map<$(&self.render_type(key_type, type_helper)), $(&self.render_type(value_type, type_helper))>)
             }
             Type::Enum { name, .. } => quote!($(DartCodeOracle::class_name(name))),
-            Type::Record { name, .. } => quote!($name),
-            Type::Custom { name, .. } => quote!($name),
+            Type::Record { name, .. } => quote!($(DartCodeOracle::class_name(name))),
+            Type::Custom { name, .. } => quote!($(DartCodeOracle::class_name(name))),
             Type::Duration => quote!(Duration),
-            Type::CallbackInterface { name, .. } => quote!($name),
+            Type::CallbackInterface { name, .. } => quote!($(DartCodeOracle::class_name(name))),
             _ => todo!("Type::{:?}", ty),
         };
 

--- a/src/gen/types.rs
+++ b/src/gen/types.rs
@@ -607,8 +607,8 @@ pub fn generate_type(ty: &Type) -> dart::Tokens {
         }
         Type::Enum { name, .. } => quote!($(DartCodeOracle::class_name(name))),
         Type::Duration => quote!(Duration),
-        Type::Record { name, .. } => quote!($name),
-        Type::Custom { name, .. } => quote!($name),
+        Type::Record { name, .. } => quote!($(DartCodeOracle::class_name(name))),
+        Type::Custom { name, .. } => quote!($(DartCodeOracle::class_name(name))),
         _ => todo!("Type::{:?}", ty),
     }
 }


### PR DESCRIPTION
Found in interface types, but also fixed in callback interfaces, records and custom types.

Includes a regression test in the custom types fixture.

This is not a breaking change: users who were already using the Rust naming convention e.g. `Url`, `HttpMetadata` were not seeing this bug. Users who were using all caps, e.g. `URL`, `HTTPMetadata` were getting compile errors in generated Dart.

This fixes that.