### PR TITLE
chore: bump uniffi-rs to 0.31.2 to ensure reproducible builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,8 @@ members = [
 ]
 
 [workspace.dependencies]
-uniffi = { version = "0.31.1" }
-uniffi_bindgen = { version = "0.31.1" }
-uniffi_build = { version = "0.31.1" }
-uniffi_testing = { version = "0.31.1" }
+uniffi = { version = "0.31.2" }
+uniffi_bindgen = { version = "0.31.2" }
+uniffi_build = { version = "0.31.2" }
+uniffi_testing = { version = "0.31.2" }
 camino = { version = "1.1" }


### PR DESCRIPTION
`0.31.2` makes binding codegen deterministic via [mozilla/uniffi-rs@b4153d4](https://github.com/mozilla/uniffi-rs/commit/b4153d4) ("sort uniffi_traits to ensure deterministic code generation").
