### PR TITLE
Prepare v0.2.1+v0.31.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to uniffi-dart will be documented in this file.
 
+## v0.2.1+v0.31.2
+
+### Changes
+
+- Upgrade uniffi-rs from v0.31.1 to v0.31.2 (#146)
+
+### Fixes
+
+- Fix name mangling for all-caps acronym identifiers (#145)
+- Register recursive type helpers so recursive types generate correctly (#138)
+- Generate Rust-backed proxies for callback trait interfaces and handle
+  tagged callback interface pointers (#135)
+- Make the ordering of generated Dart type helpers deterministic (#134)
+
+## v0.2.0+v0.31.1
+
+### Breaking changes
+
+- **BREAKING**: Upgrade uniffi-rs from v0.30.0 to v0.31.1 (#125)
+
+### Fixes
+
+- Generate FfiConverter for Sequence/Optional of records in callback interfaces (#117)
+- Fix Dart error object renaming (#120)
+- Use Optional FfiConverter's `lower()` for inner types to avoid double-wrapping nullable records in callback return values (#121)
+- Make nullable record fields optional in Dart constructors (#122)
+
 ## v0.1.0+v0.30.0
 
 Initial release of uniffi-dart targeting uniffi-rs v0.30.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi-dart"
-version = "0.1.0+v0.30.0"
+version = "0.2.1+v0.31.2"
 edition = "2021"
 license = "Apache-2 or MIT"
 homepage = "https://github.com/acterglobal/uniffi-dart"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add uniffi-dart as a dependency in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-uniffi-dart = "0.2.0+v0.31.1"
+uniffi-dart = "0.2.1+v0.31.2"
 ```
 
 ## Testing & Fixtures
@@ -126,7 +126,7 @@ uniffi-dart version and `A.B.C` is the targeted uniffi-rs version.
 
 | uniffi-rs target | Latest uniffi-dart release |
 |------------------|----------------------------|
-| v0.31.1          | v0.2.0+v0.31.1             |
+| v0.31.2          | v0.2.1+v0.31.2             |
 | v0.30.0          | v0.1.1+v0.30.0             |
 
 ## License & Credits

--- a/uniffi_dart_macro/Cargo.toml
+++ b/uniffi_dart_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniffi_dart_macro"
-version = "0.1.0+v0.30.0"
+version = "0.2.1+v0.31.2"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Closes #147.

Prepares the `v0.2.1+v0.31.2` release on the uniffi-rs 0.31 line. This
targets `main` because `main` is still on the 0.31 line (workspace
uniffi deps are at 0.31.2). After merge, `release/uniffi-v0.31.x` will
be advanced to this commit and the `v0.2.1+v0.31.2` tag created.

### Changes

- Bump `version` to `0.2.1+v0.31.2` in `Cargo.toml` and
  `uniffi_dart_macro/Cargo.toml` (and regenerate `Cargo.lock`).
- Update the README install snippet and the versioning table row for
  the 0.31 line.
- Add the `v0.2.1+v0.31.2` CHANGELOG entry.
- Backfill the `v0.2.0+v0.31.1` CHANGELOG entry, which until now lived
  only on `release/uniffi-v0.31.x`, so `main` carries the full 0.31-line
  changelog before the release branch is advanced to it.

### Release notes (since v0.2.0+v0.31.1)

- Upgrade uniffi-rs from v0.31.1 to v0.31.2 (#146)
- Fix name mangling for all-caps acronym identifiers (#145)
- Register recursive type helpers so recursive types generate correctly (#138)
- Generate Rust-backed proxies for callback trait interfaces and handle
  tagged callback interface pointers (#135)
- Make the ordering of generated Dart type helpers deterministic (#134)