### PR TITLE
Fix clippy 1.97 useless_borrows_in_formatting on main

### DIFF
--- a/src/gen/callback_interface.rs
+++ b/src/gen/callback_interface.rs
@@ -359,7 +359,7 @@ pub fn generate_callback_functions(
 
         // Generate the function body
         let callback_method_name =
-            &format!("{}{}", &DartCodeOracle::fn_name(callback_name), &DartCodeOracle::class_name(m.name()));
+            &format!("{}{}", DartCodeOracle::fn_name(callback_name), DartCodeOracle::class_name(m.name()));
 
         if m.is_async() {
             let completion_base = foreign_future_completion_name(m);

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -36,7 +36,7 @@ impl CodeType for EnumCodeType {
     }
 
     fn ffi_converter_name(&self) -> String {
-        format!("FfiConverter{}", &DartCodeOracle::class_name(&self.id))
+        format!("FfiConverter{}", DartCodeOracle::class_name(&self.id))
     }
 }
 

--- a/src/gen/render/mod.rs
+++ b/src/gen/render/mod.rs
@@ -57,7 +57,7 @@ pub trait Renderable {
         };
 
         if !type_helper.include_once_check(&ty.as_codetype().canonical_name(), ty) {
-            println!("{} Added", &ty.as_codetype().canonical_name());
+            println!("{} Added", ty.as_codetype().canonical_name());
         }
 
         type_name

--- a/src/gen/stream/mod.rs
+++ b/src/gen/stream/mod.rs
@@ -8,7 +8,7 @@ pub fn generate_stream(obj: &Object, _type_helper: &dyn TypeHelperRenderer) -> d
     let obj_name = obj.name();
     let fn_name = DartCodeOracle::fn_name(&obj_name.replace("StreamExt", ""));
     let obj_var_name = &DartCodeOracle::var_name(&fn_name);
-    let create_obj_fn_name = format!("createStream{}", &obj_name.replace("StreamExt", ""));
+    let create_obj_fn_name = format!("createStream{}", obj_name.replace("StreamExt", ""));
 
     quote! {
         $fn_name() async* {


### PR DESCRIPTION
## What

Removes five redundant `&` borrows in `format!`/`println!` arguments, in four files. `Display` for `&T` forwards to `Display` for `T`, so the output is byte-identical.

## Why

Clippy 1.97 extended `useless_borrows_in_formatting` to cover these, and the CI runners now ship stable 1.97.1. `main` last ran CI in June, so it still shows green — but any fresh `Lints (stable)` run fails on these lines. The run on #156 shows this: it flags `enums.rs:39`, `render/mod.rs:60`, and `stream/mod.rs:11`, none of which that PR touches.

Verified locally: `cargo +stable clippy -- -D warnings` (clippy 1.98.0) reports five `redundant reference` errors on `main`, and none with this change.

## Context

The same change is currently riding along in #149, #152, and #157, and was reverted from #150 after a review discussion in which the failure could not be reproduced (the reproduction attempt used an outdated toolchain — that was my error, corrected on the threads). Landing it once here lets all four branches rebase or drop their copies, and un-reds `main` for every future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

